### PR TITLE
$LOW_FIELD_FILENAME_* as defined in LibreOfficeWriter_Constants.au3

### DIFF
--- a/LibreOfficeWriter.au3
+++ b/LibreOfficeWriter.au3
@@ -15131,13 +15131,9 @@ EndFunc   ;==>_LOWriter_FieldDocInfoTitleModify
 ;				   +										File Name Field Object.
 ; Author ........: donnyh13
 ; Modified ......:
-; Remarks .......: Until at least L.O. Version 7.3.4.2, there is a bug where the wrong Path Format type is displayed when the
-;						content is set to Fixed = True. For example, $LOW_FIELD_FILENAME_NAME_AND_EXT, displays in the format
-;							of $LOW_FIELD_FILENAME_NAME.
-;File Name Constants: $LOW_FIELD_FILENAME_FULL_PATH(0), The content of the URL is completely displayed.
-;						$LOW_FIELD_FILENAME_PATH(1), Only the path of the file is displayed.
-;						$LOW_FIELD_FILENAME_NAME(2), Only the name of the file without the file extension is displayed.
-;						$LOW_FIELD_FILENAME_NAME_AND_EXT(3), The file name including the file extension is displayed.
+; Remarks .......: Until at least L.O. Version 7.3.4.2, there is a bug where the wrong Path Format type is displayed when the content is set to Fixed = True.
+;				   For example, $LOW_FIELD_FILENAME_NAME_AND_EXT, displays in the format of $LOW_FIELD_FILENAME_NAME.
+; File Name Constants: $LOW_FIELD_FILENAME_* as defined in LibreOfficeWriter_Constants.au3
 ; Related .......: _LOWriter_FieldFileNameModify, _LOWriter_DocGetViewCursor, _LOWriter_DocCreateTextCursor,
 ;					_LOWriter_CellCreateTextCursor, _LOWriter_FrameCreateTextCursor, _LOWriter_DocHeaderGetTextCursor,
 ;					_LOWriter_DocFooterGetTextCursor, _LOWriter_EndnoteGetTextCursor, _LOWriter_FootnoteGetTextCursor

--- a/LibreOfficeWriter_Constants.au3
+++ b/LibreOfficeWriter_Constants.au3
@@ -639,10 +639,10 @@ Global Const _ ; User Data Field Type
 		$LOW_FIELD_USER_DATA_STATE = 14
 
 Global Const _ ; File Name Field Type
-		$LOW_FIELD_FILENAME_FULL_PATH = 0, _
-		$LOW_FIELD_FILENAME_PATH = 1, _
-		$LOW_FIELD_FILENAME_NAME = 2, _
-		$LOW_FIELD_FILENAME_NAME_AND_EXT = 3, _
+		$LOW_FIELD_FILENAME_FULL_PATH = 0, _ ; The content of the URL is completely displayed.
+		$LOW_FIELD_FILENAME_PATH = 1, _ ; Only the path of the file is displayed.
+		$LOW_FIELD_FILENAME_NAME = 2, _ ; Only the name of the file without the file extension is displayed.
+		$LOW_FIELD_FILENAME_NAME_AND_EXT = 3, _ ; The file name including the file extension is displayed.
 		$LOW_FIELD_FILENAME_CATEGORY = 4, _
 		$LOW_FIELD_FILENAME_TEMPLATE_NAME = 5
 


### PR DESCRIPTION
This is first time when Const description from function headers are moved to LibreOfficeWriter_Constants.au3

All others cases should be similarly changed.