### PR TITLE
Fix Alignment to Col. 41; Writer Bug from previous P.R.; and Array Dimension error.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -673,6 +673,9 @@ Go to [legend](#legend---types-of-changes) for further information about the typ
 - _LOWriter_DocHyperlinkInsert -- $bOverwrite parameter was not used in function.
 - Transparency causing Color values to be returned that including the Alpha value, causing potentially unexpected results.
 - Missing Data Type in _LOWriter_CursorGetDataType example.
+- _LOWriter_DocCreateTextCursor would throw an error when creating a Text Cursor at the ViewCursor position.
+- When any FieldsGetList functions were supposed to return a single dimension array, a two dimensional array was being returned.
+- Incorrect usage of ObjEvent.
 
 ### Removed
 

--- a/Examples/_LOCalc_DocGetPath.au3
+++ b/Examples/_LOCalc_DocGetPath.au3
@@ -16,7 +16,7 @@ Func Example()
 	; Create a unique file name
 	$sSavePath = _TempFile(@TempDir & "\", "DocTestFile_", ".ods")
 
-	; Save The New Blank Doc To Desktop Directory.
+	; Save The New Blank Doc To Temp Directory.
 	$sPath = _LOCalc_DocSaveAs($oDoc, $sSavePath, "", True)
 	If @error Then _ERROR($oDoc, "Failed to save the Calc Document. Error:" & @error & " Extended:" & @extended)
 

--- a/Examples/_LOCalc_DocHasPath.au3
+++ b/Examples/_LOCalc_DocHasPath.au3
@@ -23,7 +23,7 @@ Func Example()
 	; Create a unique file name
 	$sSavePath = _TempFile(@TempDir & "\", "DocTestFile_", ".ods")
 
-	; Save The New Blank Doc To Desktop Directory.
+	; Save The New Blank Doc To Temp Directory.
 	$sPath = _LOCalc_DocSaveAs($oDoc, $sSavePath, "", True)
 	If @error Then _ERROR($oDoc, "Failed to save the Calc Document. Error:" & @error & " Extended:" & @extended)
 

--- a/LibreOfficeCalc_Cursor.au3
+++ b/LibreOfficeCalc_Cursor.au3
@@ -439,7 +439,7 @@ EndFunc   ;==>_LOCalc_TextCursorFontColor
 ; Name ..........: _LOCalc_TextCursorGetString
 ; Description ...: Retrieve the string of text currently selected by a cursor or contained in a paragraph object.
 ; Syntax ........: _LOCalc_TextCursorGetString(ByRef $oObj)
-; Parameters ....: $oObj             - [in/out] an object. A Text Cursor Object returned by a previous _LOCalc_PageStyleFooterCreateTextCursor, _LOCalc_PageStyleHeaderCreateTextCursor, or _LOCalc_CellCreateTextCursor function.
+; Parameters ....: $oObj                - [in/out] an object. A Text Cursor Object returned by a previous _LOCalc_PageStyleFooterCreateTextCursor, _LOCalc_PageStyleHeaderCreateTextCursor, or _LOCalc_CellCreateTextCursor function.
 ; Return values .: Success: String
 ;                  Failure: 0 and sets the @Error and @Extended flags to non-zero.
 ;                  --Input Errors--

--- a/LibreOfficeCalc_Doc.au3
+++ b/LibreOfficeCalc_Doc.au3
@@ -994,15 +994,15 @@ EndFunc   ;==>_LOCalc_DocMinimize
 ; Example .......: Yes
 ; ===============================================================================================================================
 Func _LOCalc_DocOpen($sFilePath, $bConnectIfOpen = True, $bHidden = Null, $bReadOnly = Null, $sPassword = Null, $bLoadAsTemplate = Null, $sFilterName = Null)
+	Local $oCOM_ErrorHandler = ObjEvent("AutoIt.Error", __LOCalc_InternalComErrorHandler)
+	#forceref $oCOM_ErrorHandler
+
 	Local Const $iURLFrameCreate = 8 ;frame will be created if not found
 	Local $iError = 0
 	Local $oDoc, $oServiceManager, $oDesktop
 	Local $aoProperties[0]
 	Local $vProperty
 	Local $sFileURL
-
-	Local $oCOM_ErrorHandler = ObjEvent("AutoIt.Error", "__LOCalc_InternalComErrorHandler")
-	#forceref $oCOM_ErrorHandler
 
 	If Not IsString($sFilePath) Or Not FileExists($sFilePath) Then Return SetError($__LO_STATUS_INPUT_ERROR, 1, 0)
 	$sFileURL = _LOCalc_PathConvert($sFilePath, $LOC_PATHCONV_OFFICE_RETURN)
@@ -1522,8 +1522,8 @@ EndFunc   ;==>_LOCalc_DocSaveAs
 ; Modified ......:
 ; Remarks .......: Data you desire to be copied must be selected first, see _LOCalc_DocSelectionSet, _LOCalc_DocSelectionSetMulti.
 ;                  This function works essentially the same as Copy/ Ctrl+C, except it doesn't use your clipboard.
-;				   The Object returned is used in _LOCalc_DocSelectionPaste to insert the data again.
-;				   Data copied can be inserted into the same or another document.
+;                  The Object returned is used in _LOCalc_DocSelectionPaste to insert the data again.
+;                  Data copied can be inserted into the same or another document.
 ; Related .......: _LOCalc_DocSelectionPaste, _LOCalc_DocSelectionSet, _LOCalc_DocSelectionSetMulti
 ; Link ..........:
 ; Example .......: Yes

--- a/LibreOfficeCalc_Doc.au3
+++ b/LibreOfficeCalc_Doc.au3
@@ -77,7 +77,7 @@
 ; Name ..........: _LOCalc_DocClose
 ; Description ...: Close an existing Calc Document, returning its save path if applicable.
 ; Syntax ........: _LOCalc_DocClose(ByRef $oDoc[, $bSaveChanges = True[, $sSaveName = ""[, $bDeliverOwnership = True]]])
-; Parameters ....: $oDoc                   - [in/out] an object. A Document object returned by a previous _LOCalc_DocOpen, _LOCalc_DocConnect, or _LOCalc_DocCreate function.
+; Parameters ....: $oDoc                - [in/out] an object. A Document object returned by a previous _LOCalc_DocOpen, _LOCalc_DocConnect, or _LOCalc_DocCreate function.
 ;                  $bSaveChanges        - [optional] a boolean value. Default is True. If true, saves changes if any were made before closing. See remarks.
 ;                  $sSaveName           - [optional] a string value. Default is "". The file name to save the file as, if the file hasn't been saved before. See Remarks.
 ;                  $bDeliverOwnership   - [optional] a boolean value. Default is True. If True, deliver ownership of the document Object from the script to LibreOffice, recommended is True.
@@ -99,7 +99,7 @@
 ; Author ........: donnyh13
 ; Modified ......:
 ; Remarks .......: If $bSaveChanges is true and the document hasn't been saved yet, the document is saved to the desktop.
-;                  If $sSaveName is undefined, it is saved as an .odt document to the desktop, named Year-Month-Day_Hour-Minute-Second.ods. $sSaveName may be a name only without an extension, in which case the file will be saved in .ods format. Or you may define your own format by including an extension, such as "Test.xlsx"
+;                  If $sSaveName is undefined, it is saved as an .ods document to the desktop, named Year-Month-Day_Hour-Minute-Second.ods. $sSaveName may be a name only without an extension, in which case the file will be saved in .ods format. Or you may define your own format by including an extension, such as "Test.xlsx"
 ; Related .......: _LOCalc_DocOpen, _LOCalc_DocConnect, _LOCalc_DocCreate, _LOCalc_DocSaveAs, _LOCalc_DocSave
 ; Link ..........:
 ; Example .......: Yes
@@ -379,8 +379,8 @@ EndFunc   ;==>_LOCalc_DocConnect
 ; Name ..........: _LOCalc_DocCreate
 ; Description ...: Open a new Libre Office Calc Document or Connect to an existing blank, unsaved, writable document.
 ; Syntax ........: _LOCalc_DocCreate([$bForceNew = True[, $bHidden = False]])
-; Parameters ....: $bForceNew       - [optional] a boolean value. Default is True. If True, force opening a new Calc Document instead of checking for a usable blank.
-;                  $bHidden         - [optional] a boolean value. Default is False. If True opens the new document invisible or changes the existing document to invisible.
+; Parameters ....: $bForceNew           - [optional] a boolean value. Default is True. If True, force opening a new Calc Document instead of checking for a usable blank.
+;                  $bHidden             - [optional] a boolean value. Default is False. If True opens the new document invisible or changes the existing document to invisible.
 ; Return values .: Success: Object
 ;                  Failure: 0 and sets the @Error and @Extended flags to non-zero.
 ;                  --Input Errors--
@@ -567,12 +567,12 @@ EndFunc   ;==>_LOCalc_DocEnumPrintersAlt
 ; Name ..........: _LOCalc_DocExport
 ; Description ...: Export a Document with the specified file name to the path specified, with any parameters used.
 ; Syntax ........: _LOCalc_DocExport(ByRef $oDoc, $sFilePath[, $bSamePath = False[, $sFilterName = ""[, $bOverwrite = Null[, $sPassword = Null]]]])
-; Parameters ....: $oDoc           - [in/out] an object. A Document object returned by a previous _LOCalc_DocOpen, _LOCalc_DocConnect, or _LOCalc_DocCreate function.
-;                  $sFilePath      - a string value. Full path to save the document to, including Filename and extension. See Remarks.
-;                  $bSamePath      - [optional] a boolean value. Default is False. If True, uses the path of the current document to export to. See Remarks
-;                  $sFilterName    - [optional] a string value. Default is "". Filter name. If set to "" (blank string), Filter is chosen automatically based on the file extension. If no extension is present, or if not matched to the list of extensions in this UDF, the .ods extension is used instead, with the filter name of "calc8".
-;                  $bOverwrite     - [optional] a boolean value. Default is Null. If True, file will be overwritten.
-;                  $sPassword      - [optional] a string value. Default is Null. Password String to set for the document. (Not all file formats can have a Password set). "" (blank string) or Null = No Password.
+; Parameters ....: $oDoc                - [in/out] an object. A Document object returned by a previous _LOCalc_DocOpen, _LOCalc_DocConnect, or _LOCalc_DocCreate function.
+;                  $sFilePath           - a string value. Full path to save the document to, including Filename and extension. See Remarks.
+;                  $bSamePath           - [optional] a boolean value. Default is False. If True, uses the path of the current document to export to. See Remarks
+;                  $sFilterName         - [optional] a string value. Default is "". Filter name. If set to "" (blank string), Filter is chosen automatically based on the file extension. If no extension is present, or if not matched to the list of extensions in this UDF, the .ods extension is used instead, with the filter name of "calc8".
+;                  $bOverwrite          - [optional] a boolean value. Default is Null. If True, file will be overwritten.
+;                  $sPassword           - [optional] a string value. Default is Null. Password String to set for the document. (Not all file formats can have a Password set). "" (blank string) or Null = No Password.
 ; Return values .: Success: String
 ;                  Failure: 0 and sets the @Error and @Extended flags to non-zero.
 ;                  --Input Errors--
@@ -1407,7 +1407,7 @@ EndFunc   ;==>_LOCalc_DocRedoIsPossible
 ; Name ..........: _LOCalc_DocSave
 ; Description ...: Save any changes made to a Document.
 ; Syntax ........: _LOCalc_DocSave(ByRef $oDoc)
-; Parameters ....: $oDoc           - [in/out] an object. A Document object returned by a previous _LOCalc_DocOpen, _LOCalc_DocConnect, or _LOCalc_DocCreate function.
+; Parameters ....: $oDoc                - [in/out] an object. A Document object returned by a previous _LOCalc_DocOpen, _LOCalc_DocConnect, or _LOCalc_DocCreate function.
 ; Return values .: Success: 1
 ;                  Failure: 0 and sets the @Error and @Extended flags to non-zero.
 ;                  --Input Errors--

--- a/LibreOfficeCalc_Helper.au3
+++ b/LibreOfficeCalc_Helper.au3
@@ -1235,7 +1235,7 @@ EndFunc   ;==>_LOCalc_FormatKeyList
 ;                  @Error 0 @Extended 2 Return String = Returning converted path from File Path to Libre Office URL.
 ; Author ........: donnyh13
 ; Modified ......:
-; Remarks .......: LibeOffice URL notation is based on the Internet Standard RFC 1738, which means only [0-9],[a-zA-Z] are allowed in paths, most other characters need to be converted into ISO 8859-1 (ISO Latin) such as is found in internet URL's (spaces become %20). See: StarOfficeTM 6.0 Office SuiteA SunTM ONE Software Offering, Basic Programmer's Guide; Page 74
+; Remarks .......: LibreOffice URL notation is based on the Internet Standard RFC 1738, which means only [0-9],[a-zA-Z] are allowed in paths, most other characters need to be converted into ISO 8859-1 (ISO Latin) such as is found in internet URL's (spaces become %20). See: StarOfficeTM 6.0 Office SuiteA SunTM ONE Software Offering, Basic Programmer's Guide; Page 74
 ;                  The user generally should not even need this function, as I have endeavored to convert any URLs to the appropriate computer path format and any input computer paths to a Libre Office URL.
 ; Related .......:
 ; Link ..........:

--- a/LibreOfficeCalc_Internal.au3
+++ b/LibreOfficeCalc_Internal.au3
@@ -2011,7 +2011,7 @@ EndFunc   ;==>__LOCalc_CommentLineStyleName
 ; Name ..........: __LOCalc_CreateStruct
 ; Description ...: Creates a Struct.
 ; Syntax ........: __LOCalc_CreateStruct($sStructName)
-; Parameters ....: $sStructName - a string value. Name of structure to create.
+; Parameters ....: $sStructName         - a string value. Name of structure to create.
 ; Return values .: Success: Structure.
 ;                  Failure: 0 and sets the @Error and @Extended flags to non-zero.
 ;                  --Input Errors--
@@ -2190,14 +2190,14 @@ EndFunc   ;==>__LOCalc_FieldTypeServices
 ; #INTERNAL_USE_ONLY# ===========================================================================================================
 ; Name ..........: __LOCalc_FilterNameGet
 ; Description ...: Retrieves the correct L.O. Filtername for use in SaveAs and Export.
-; Syntax ........: __LOCalc_FilterNameGet(ByRef $sDocSavePath[, $bIncludeExportFilters = False])
-; Parameters ....: $sDocSavePath           - [in/out] a string value. Full path with extension.
-;                  $bIncludeExportFilters  - [optional] a boolean value. Default is False. If True, includes the FilterNames that can be used to Export only, in the search.
+; Syntax ........: __LOCalc_FilterNameGet(ByRef $sDocSavePath[, $bExportFilters = False])
+; Parameters ....: $sDocSavePath        - [in/out] a string value. Full path with extension.
+;                  $bExportFilters      - [optional] a boolean value. Default is False. If True, includes the FilterNames that can be used to Export only, in the search.
 ; Return values .: Success: String.
 ;                  Failure: 0 and sets the @Error and @Extended flags to non-zero.
 ;                  --Input Errors--
 ;                  @Error 1 @Extended 1 Return 0 = $sDocSavePath is not a string.
-;                  @Error 1 @Extended 2 Return 0 = $bIncludeExportFilters not a Boolean.
+;                  @Error 1 @Extended 2 Return 0 = $bExportFilters not a Boolean.
 ;                  @Error 1 @Extended 3 Return 0 = $sDocSavePath is not a correct path or URL.
 ;                  --Success--
 ;                  @Error 0 @Extended 1 Return String = Success. Returns required filtername from "SaveAs" FilterNames.
@@ -2212,14 +2212,14 @@ EndFunc   ;==>__LOCalc_FieldTypeServices
 ; Link ..........:
 ; Example .......: No
 ; ===============================================================================================================================
-Func __LOCalc_FilterNameGet(ByRef $sDocSavePath, $bIncludeExportFilters = False)
+Func __LOCalc_FilterNameGet(ByRef $sDocSavePath, $bExportFilters = False)
 	Local $iLength, $iSlashLocation, $iDotLocation
 	Local Const $STR_NOCASESENSE = 0, $STR_STRIPALL = 8
 	Local $sFileExtension, $sFilterName
 	Local $msSaveAsFilters[], $msExportFilters[]
 
 	If Not IsString($sDocSavePath) Then Return SetError($__LO_STATUS_INPUT_ERROR, 1, 0)
-	If Not IsBool($bIncludeExportFilters) Then Return SetError($__LO_STATUS_INPUT_ERROR, 2, 0)
+	If Not IsBool($bExportFilters) Then Return SetError($__LO_STATUS_INPUT_ERROR, 2, 0)
 	$iLength = StringLen($sDocSavePath)
 
 	$msSaveAsFilters[".csv"] = "Text - txt - csv (StarCalc)"
@@ -2252,7 +2252,7 @@ Func __LOCalc_FilterNameGet(ByRef $sDocSavePath, $bIncludeExportFilters = False)
 	$msSaveAsFilters[".xlw"] = "MS Excel 97"
 	$msSaveAsFilters[".xml"] = "OpenDocument Spreadsheet Flat XML"
 
-	If $bIncludeExportFilters Then
+	If $bExportFilters Then
 		$msExportFilters[".jfif"] = "calc_jpg_Export"
 		$msExportFilters[".jif"] = "calc_jpg_Export"
 		$msExportFilters[".jpe"] = "calc_jpg_Export"
@@ -2285,7 +2285,7 @@ Func __LOCalc_FilterNameGet(ByRef $sDocSavePath, $bIncludeExportFilters = False)
 
 	If IsString($sFilterName) Then Return SetError($__LO_STATUS_SUCCESS, 1, $sFilterName)
 
-	If $bIncludeExportFilters Then $sFilterName = $msExportFilters[$sFileExtension]
+	If $bExportFilters Then $sFilterName = $msExportFilters[$sFileExtension]
 
 	If IsString($sFilterName) Then Return SetError($__LO_STATUS_SUCCESS, 2, $sFilterName)
 
@@ -3397,7 +3397,7 @@ EndFunc   ;==>__LOCalc_VarsAreNull
 ; Name ..........: __LOCalc_VersionCheck
 ; Description ...: Test if the currently installed LibreOffice version is high enough to support a certain function.
 ; Syntax ........: __LOCalc_VersionCheck($fRequiredVersion)
-; Parameters ....: $fRequiredVersion            - a floating point value. The version of LibreOffice required.
+; Parameters ....: $fRequiredVersion    - a floating point value. The version of LibreOffice required.
 ; Return values .: Success: Boolean.
 ;                  Failure: 0 and sets the @Error and @Extended flags to non-zero.
 ;                  --Input Errors--

--- a/LibreOfficeCalc_Page.au3
+++ b/LibreOfficeCalc_Page.au3
@@ -1214,8 +1214,8 @@ EndFunc   ;==>_LOCalc_PageStyleFooterShadow
 ; Name ..........: _LOCalc_PageStyleGetObj
 ; Description ...: Retrieve a Page Style Object for use with other Page Style functions.
 ; Syntax ........: _LOCalc_PageStyleGetObj(ByRef $oDoc, $sPageStyle)
-; Parameters ....: $oDoc                 - [in/out] an object. A Document object returned by a previous _LOCalc_DocOpen, _LOCalc_DocConnect, or _LOCalc_DocCreate function.
-;                  $sPageStyle           - a string value. The Page Style name to retrieve the Object for.
+; Parameters ....: $oDoc                - [in/out] an object. A Document object returned by a previous _LOCalc_DocOpen, _LOCalc_DocConnect, or _LOCalc_DocCreate function.
+;                  $sPageStyle          - a string value. The Page Style name to retrieve the Object for.
 ; Return values .: Success: Object
 ;                  Failure: 0 and sets the @Error and @Extended flags to non-zero.
 ;                  --Input Errors--

--- a/LibreOfficeCalc_Sheet.au3
+++ b/LibreOfficeCalc_Sheet.au3
@@ -1495,7 +1495,7 @@ EndFunc   ;==>_LOCalc_SheetsGetNames
 ; Remarks .......: Call this function with only the required parameters (or with all other parameters set to Null keyword), to get the current settings.
 ; Related .......: _LOCalc_ConvertColorFromLong, _LOCalc_ConvertColorToLong
 ; Link ..........:
-; Example .......: No
+; Example .......: Yes
 ; ===============================================================================================================================
 Func _LOCalc_SheetTabColor(ByRef $oSheet, $iColor = Null)
 	Local $oCOM_ErrorHandler = ObjEvent("AutoIt.Error", __LOCalc_InternalComErrorHandler)

--- a/LibreOfficeCalc_Sheet.au3
+++ b/LibreOfficeCalc_Sheet.au3
@@ -833,7 +833,6 @@ EndFunc   ;==>_LOCalc_SheetLink
 ;                  --Success--
 ;                  @Error 0 @Extended 0 Return 1 = Success. Settings were successfully set.
 ;                  @Error 0 @Extended 1 Return Array = Success. All optional parameters were set to Null, returning current settings in a 3 Element Array with values in order of function parameters.
-;~
 ; Author ........: donnyh13
 ; Modified ......:
 ; Remarks .......: Call this function with only the required parameters (or with all other parameters set to Null keyword), to get the current settings.

--- a/LibreOfficeWriter_Char.au3
+++ b/LibreOfficeWriter_Char.au3
@@ -282,8 +282,8 @@ EndFunc   ;==>_LOWriter_CharStyleBorderWidth
 ; Name ..........: _LOWriter_CharStyleCreate
 ; Description ...: Create a new Character Style in a Document.
 ; Syntax ........: _LOWriter_CharStyleCreate(ByRef $oDoc, $sCharStyle)
-; Parameters ....: $oDoc           - [in/out] an object. A Document object returned by a previous _LOWriter_DocOpen, _LOWriter_DocConnect, or _LOWriter_DocCreate function.
-;                  $sCharStyle     - a string value. The name of the new Character Style to create.
+; Parameters ....: $oDoc                - [in/out] an object. A Document object returned by a previous _LOWriter_DocOpen, _LOWriter_DocConnect, or _LOWriter_DocCreate function.
+;                  $sCharStyle          - a string value. The name of the new Character Style to create.
 ; Return values .: Success: Object
 ;                  Failure: 0 and sets the @Error and @Extended flags to non-zero.
 ;                  --Input Errors--
@@ -446,8 +446,8 @@ EndFunc   ;==>_LOWriter_CharStyleEffect
 ; Name ..........: _LOWriter_CharStyleExists
 ; Description ...: Check whether a document contains a Character Style by Name.
 ; Syntax ........: _LOWriter_CharStyleExists(ByRef $oDoc, $sCharStyle)
-; Parameters ....: $oDoc           - [in/out] an object. A Document object returned by a previous _LOWriter_DocOpen, _LOWriter_DocConnect, or _LOWriter_DocCreate function.
-;                  $sCharStyle     - a string value. The Character Style name to search for.
+; Parameters ....: $oDoc                - [in/out] an object. A Document object returned by a previous _LOWriter_DocOpen, _LOWriter_DocConnect, or _LOWriter_DocCreate function.
+;                  $sCharStyle          - a string value. The Character Style name to search for.
 ; Return values .: Success: Boolean
 ;                  Failure: 0 and sets the @Error and @Extended flags to non-zero.
 ;                  --Input Errors--

--- a/LibreOfficeWriter_DirectFormatting.au3
+++ b/LibreOfficeWriter_DirectFormatting.au3
@@ -2072,9 +2072,9 @@ EndFunc   ;==>_LOWriter_DirFrmtParTabStopCreate
 ; Name ..........: _LOWriter_DirFrmtParTabStopDelete
 ; Description ...: Delete a TabStop from a Paragraph by Direct Formatting.
 ; Syntax ........: _LOWriter_DirFrmtParTabStopDelete(ByRef $oDoc, ByRef $oSelection, $iTabStop)
-; Parameters ....: $oDoc            - [in/out] an object. A Document object returned by a previous _LOWriter_DocOpen, _LOWriter_DocConnect, or _LOWriter_DocCreate function.
-;                  $oSelection      - [in/out] an object. A Cursor Object returned from any Cursor Object creation or retrieval functions, Or A Paragraph Object/Object Section returned from _LOWriter_ParObjCreateList or _LOWriter_ParObjSectionsGet function.
-;                  $iTabStop        - an integer value. The TabStop position of the TabStop to modify. See Remarks.
+; Parameters ....: $oDoc                - [in/out] an object. A Document object returned by a previous _LOWriter_DocOpen, _LOWriter_DocConnect, or _LOWriter_DocCreate function.
+;                  $oSelection          - [in/out] an object. A Cursor Object returned from any Cursor Object creation or retrieval functions, Or A Paragraph Object/Object Section returned from _LOWriter_ParObjCreateList or _LOWriter_ParObjSectionsGet function.
+;                  $iTabStop            - an integer value. The TabStop position of the TabStop to modify. See Remarks.
 ; Return values .: Success: Boolean.
 ;                  Failure: 0 and sets the @Error and @Extended flags to non-zero.
 ;                  --Input Errors--
@@ -2114,7 +2114,7 @@ EndFunc   ;==>_LOWriter_DirFrmtParTabStopDelete
 ; Name ..........: _LOWriter_DirFrmtParTabStopList
 ; Description ...: Retrieve a List of TabStops available in a Paragraph from Direct Formatting.
 ; Syntax ........: _LOWriter_DirFrmtParTabStopList(ByRef $oSelection)
-; Parameters ....: $oSelection             - [in/out] an object. A Cursor Object returned from any Cursor Object creation or retrieval functions, Or A Paragraph Object/Object Section returned from _LOWriter_ParObjCreateList or _LOWriter_ParObjSectionsGet function.
+; Parameters ....: $oSelection          - [in/out] an object. A Cursor Object returned from any Cursor Object creation or retrieval functions, Or A Paragraph Object/Object Section returned from _LOWriter_ParObjCreateList or _LOWriter_ParObjSectionsGet function.
 ; Return values .: Success: Array
 ;                  Failure: 0 and sets the @Error and @Extended flags to non-zero.
 ;                  --Input Errors--

--- a/LibreOfficeWriter_Doc.au3
+++ b/LibreOfficeWriter_Doc.au3
@@ -390,7 +390,7 @@ EndFunc   ;==>_LOWriter_DocBookmarksList
 ; Name ..........: _LOWriter_DocClose
 ; Description ...: Close an existing Writer Document, returning its save path if applicable.
 ; Syntax ........: _LOWriter_DocClose(ByRef $oDoc[, $bSaveChanges = True[, $sSaveName = ""[, $bDeliverOwnership = True]]])
-; Parameters ....: $oDoc                   - [in/out] an object. A Document object returned by a previous _LOWriter_DocOpen, _LOWriter_DocConnect, or _LOWriter_DocCreate function.
+; Parameters ....: $oDoc                - [in/out] an object. A Document object returned by a previous _LOWriter_DocOpen, _LOWriter_DocConnect, or _LOWriter_DocCreate function.
 ;                  $bSaveChanges        - [optional] a boolean value. Default is True. If true, saves changes if any were made before closing. See remarks.
 ;                  $sSaveName           - [optional] a string value. Default is "". The file name to save the file as, if the file hasn't been saved before. See Remarks.
 ;                  $bDeliverOwnership   - [optional] a boolean value. Default is True. If True, deliver ownership of the document Object from the script to LibreOffice, recommended is True.
@@ -829,8 +829,8 @@ EndFunc   ;==>_LOWriter_DocConvertTextToTable
 ; Name ..........: _LOWriter_DocCreate
 ; Description ...: Open a new Libre Office Writer Document or Connect to an existing blank, unsaved, writable document.
 ; Syntax ........: _LOWriter_DocCreate([$bForceNew = True[, $bHidden = False]])
-; Parameters ....: $bForceNew       - [optional] a boolean value. Default is True. If True, force opening a new Writer Document instead of checking for a usable blank.
-;                  $bHidden         - [optional] a boolean value. Default is False. If True opens the new document invisible or changes the existing document to invisible.
+; Parameters ....: $bForceNew           - [optional] a boolean value. Default is True. If True, force opening a new Writer Document instead of checking for a usable blank.
+;                  $bHidden             - [optional] a boolean value. Default is False. If True opens the new document invisible or changes the existing document to invisible.
 ; Return values .: Success: Object
 ;                  Failure: 0 and sets the @Error and @Extended flags to non-zero.
 ;                  --Input Errors--
@@ -1250,12 +1250,12 @@ EndFunc   ;==>_LOWriter_DocExecuteDispatch
 ; Name ..........: _LOWriter_DocExport
 ; Description ...: Export a Document with the specified file name to the path specified, with any parameters used.
 ; Syntax ........: _LOWriter_DocExport(ByRef $oDoc, $sFilePath[, $bSamePath = False[, $sFilterName = ""[, $bOverwrite = Null[, $sPassword = Null]]]])
-; Parameters ....: $oDoc           - [in/out] an object. A Document object returned by a previous _LOWriter_DocOpen, _LOWriter_DocConnect, or _LOWriter_DocCreate function.
-;                  $sFilePath      - a string value. Full path to save the document to, including Filename and extension. See Remarks.
-;                  $bSamePath      - [optional] a boolean value. Default is False. If True, uses the path of the current document to export to. See Remarks
-;                  $sFilterName    - [optional] a string value. Default is "". Filter name. If set to "" (blank string), Filter is chosen automatically based on the file extension. If no extension is present, or if not matched to the list of extensions in this UDF, the .odt extension is used instead, with the filter name of "writer8".
-;                  $bOverwrite     - [optional] a boolean value. Default is Null. If True, file will be overwritten.
-;                  $sPassword      - [optional] a string value. Default is Null. Password String to set for the document. (Not all file formats can have a Password set). "" (blank string) or Null = No Password.
+; Parameters ....: $oDoc                - [in/out] an object. A Document object returned by a previous _LOWriter_DocOpen, _LOWriter_DocConnect, or _LOWriter_DocCreate function.
+;                  $sFilePath           - a string value. Full path to save the document to, including Filename and extension. See Remarks.
+;                  $bSamePath           - [optional] a boolean value. Default is False. If True, uses the path of the current document to export to. See Remarks
+;                  $sFilterName         - [optional] a string value. Default is "". Filter name. If set to "" (blank string), Filter is chosen automatically based on the file extension. If no extension is present, or if not matched to the list of extensions in this UDF, the .odt extension is used instead, with the filter name of "writer8".
+;                  $bOverwrite          - [optional] a boolean value. Default is Null. If True, file will be overwritten.
+;                  $sPassword           - [optional] a string value. Default is Null. Password String to set for the document. (Not all file formats can have a Password set). "" (blank string) or Null = No Password.
 ; Return values .: Success: String
 ;                  Failure: 0 and sets the @Error and @Extended flags to non-zero.
 ;                  --Input Errors--
@@ -2195,7 +2195,7 @@ EndFunc   ;==>_LOWriter_DocGetPath
 ; Name ..........: _LOWriter_DocGetString
 ; Description ...: Retrieve the string of text currently selected or contained in a paragraph object.
 ; Syntax ........: _LOWriter_DocGetString(ByRef $oObj)
-; Parameters ....: $oObj             - [in/out] an object. A Cursor Object returned from any Cursor Object creation or retrieval functions with Data selected, or a Paragraph Object returned from _LOWriter_ParObjCreateList function.
+; Parameters ....: $oObj                - [in/out] an object. A Cursor Object returned from any Cursor Object creation or retrieval functions with Data selected, or a Paragraph Object returned from _LOWriter_ParObjCreateList function.
 ; Return values .: Success: String
 ;                  Failure: 0 and sets the @Error and @Extended flags to non-zero.
 ;                  --Input Errors--
@@ -2232,7 +2232,7 @@ EndFunc   ;==>_LOWriter_DocGetString
 ; Name ..........: _LOWriter_DocGetViewCursor
 ; Description ...: Retrieve the ViewCursor Object from a Document.
 ; Syntax ........: _LOWriter_DocGetViewCursor(ByRef $oDoc)
-; Parameters ....: $oDoc           - [in/out] an object. A Document object returned by a previous _LOWriter_DocOpen, _LOWriter_DocConnect, or_LOWriter_DocCreate function.
+; Parameters ....: $oDoc                - [in/out] an object. A Document object returned by a previous _LOWriter_DocOpen, _LOWriter_DocConnect, or_LOWriter_DocCreate function.
 ; Return values .: Success: Object
 ;                  Failure: 0 and sets the @Error and @Extended flags to non-zero.
 ;                  --Input Errors--
@@ -3933,7 +3933,7 @@ EndFunc   ;==>_LOWriter_DocReplaceAllInRange
 ; Name ..........: _LOWriter_DocSave
 ; Description ...: Save any changes made to a Document.
 ; Syntax ........: _LOWriter_DocSave(ByRef $oDoc)
-; Parameters ....: $oDoc           - [in/out] an object. A Document object returned by a previous _LOWriter_DocOpen, _LOWriter_DocConnect, or _LOWriter_DocCreate function.
+; Parameters ....: $oDoc                - [in/out] an object. A Document object returned by a previous _LOWriter_DocOpen, _LOWriter_DocConnect, or _LOWriter_DocCreate function.
 ; Return values .: Success: 1
 ;                  Failure: 0 and sets the @Error and @Extended flags to non-zero.
 ;                  --Input Errors--

--- a/LibreOfficeWriter_Doc.au3
+++ b/LibreOfficeWriter_Doc.au3
@@ -941,8 +941,8 @@ Func _LOWriter_DocCreateTextCursor(ByRef $oDoc, $bCreateAtEnd = True, $bCreateAt
 		$oViewCursor = $oDoc.CurrentController.getViewCursor()
 		If Not IsObj($oViewCursor) Then Return SetError($__LO_STATUS_PROCESSING_ERROR, 1, 0)
 		$oText = __LOWriter_CursorGetText($oDoc, $oViewCursor)
-		If @error Or Not IsObj($oText) Then Return SetError($__LO_STATUS_PROCESSING_ERROR, 2, 0)
 		$iCursorType = @extended
+		If @error Or Not IsObj($oText) Then Return SetError($__LO_STATUS_PROCESSING_ERROR, 2, 0)
 
 		If __LOWriter_IntIsBetween($iCursorType, $LOW_CURDATA_BODY_TEXT, $LOW_CURDATA_HEADER_FOOTER) Then
 			$oCursor = $oText.createTextCursorByRange($oViewCursor)
@@ -2338,7 +2338,7 @@ EndFunc   ;==>_LOWriter_DocHasFrameName
 ; Example .......: Yes
 ; ===============================================================================================================================
 Func _LOWriter_DocHasImageName(ByRef $oDoc, $sImageName)
-	Local $oCOM_ErrorHandler = ObjEvent("AutoIt.Error", "__LOWriter_InternalComErrorHandler")
+	Local $oCOM_ErrorHandler = ObjEvent("AutoIt.Error", __LOWriter_InternalComErrorHandler)
 	#forceref $oCOM_ErrorHandler
 
 	If Not IsObj($oDoc) Then Return SetError($__LO_STATUS_INPUT_ERROR, 1, 0)

--- a/LibreOfficeWriter_Field.au3
+++ b/LibreOfficeWriter_Field.au3
@@ -1179,14 +1179,14 @@ EndFunc   ;==>_LOWriter_FieldDocInfoCommentsInsert
 ; #FUNCTION# ====================================================================================================================
 ; Name ..........: _LOWriter_FieldDocInfoCommentsModify
 ; Description ...: Set or Retrieve a Document Information Comments Field's settings.
-; Syntax ........: _LOWriter_FieldDocInfoCommentsModify(ByRef $oDocInfoCommentField[, $bIsFixed = Null[, $sComments = Null]])
-; Parameters ....: $oDocInfoCommentField  - [in/out] an object. A Doc Info Comments field Object from a previous _LOWriter_FieldDocInfoCommentsInsert, or _LOWriter_FieldsGetList function.
-;                  $bIsFixed              - [optional] a boolean value. Default is Null. If True, the value is static, that is, the value does not update if the source changes or all fields are updated.
-;                  $sComments             - [optional] a string value. Default is Null. The Comments text to display, note, $bIsFixed must be True for this to be displayed.
+; Syntax ........: _LOWriter_FieldDocInfoCommentsModify(ByRef $oDocInfoComment[, $bIsFixed = Null[, $sComments = Null]])
+; Parameters ....: $oDocInfoComment     - [in/out] an object. A Doc Info Comments field Object from a previous _LOWriter_FieldDocInfoCommentsInsert, or _LOWriter_FieldsGetList function.
+;                  $bIsFixed            - [optional] a boolean value. Default is Null. If True, the value is static, that is, the value does not update if the source changes or all fields are updated.
+;                  $sComments           - [optional] a string value. Default is Null. The Comments text to display, note, $bIsFixed must be True for this to be displayed.
 ; Return values .: Success: 1 or Array.
 ;                  Failure: 0 and sets the @Error and @Extended flags to non-zero.
 ;                  --Input Errors--
-;                  @Error 1 @Extended 1 Return 0 = $oDocInfoCommentField not an Object.
+;                  @Error 1 @Extended 1 Return 0 = $oDocInfoComment not an Object.
 ;                  @Error 1 @Extended 2 Return 0 = $bIsFixed not a Boolean.
 ;                  @Error 1 @Extended 3 Return 0 = $sComments not a String.
 ;                  --Property Setting Errors--
@@ -1204,33 +1204,33 @@ EndFunc   ;==>_LOWriter_FieldDocInfoCommentsInsert
 ; Link ..........:
 ; Example .......: Yes
 ; ===============================================================================================================================
-Func _LOWriter_FieldDocInfoCommentsModify(ByRef $oDocInfoCommentField, $bIsFixed = Null, $sComments = Null)
+Func _LOWriter_FieldDocInfoCommentsModify(ByRef $oDocInfoComment, $bIsFixed = Null, $sComments = Null)
 	Local $oCOM_ErrorHandler = ObjEvent("AutoIt.Error", __LOWriter_InternalComErrorHandler)
 	#forceref $oCOM_ErrorHandler
 
 	Local $iError = 0
 	Local $avDocInfoCom[2]
 
-	If Not IsObj($oDocInfoCommentField) Then Return SetError($__LO_STATUS_INPUT_ERROR, 1, 0)
+	If Not IsObj($oDocInfoComment) Then Return SetError($__LO_STATUS_INPUT_ERROR, 1, 0)
 
 	If __LOWriter_VarsAreNull($bIsFixed, $sComments) Then
-		__LOWriter_ArrayFill($avDocInfoCom, $oDocInfoCommentField.IsFixed(), $oDocInfoCommentField.Content())
+		__LOWriter_ArrayFill($avDocInfoCom, $oDocInfoComment.IsFixed(), $oDocInfoComment.Content())
 		Return SetError($__LO_STATUS_SUCCESS, 1, $avDocInfoCom)
 	EndIf
 
 	If ($bIsFixed <> Null) Then
 		If Not IsBool($bIsFixed) Then Return SetError($__LO_STATUS_INPUT_ERROR, 2, 0)
-		$oDocInfoCommentField.IsFixed = $bIsFixed
-		$iError = ($oDocInfoCommentField.IsFixed() = $bIsFixed) ? ($iError) : (BitOR($iError, 1))
+		$oDocInfoComment.IsFixed = $bIsFixed
+		$iError = ($oDocInfoComment.IsFixed() = $bIsFixed) ? ($iError) : (BitOR($iError, 1))
 	EndIf
 
 	If ($sComments <> Null) Then
 		If Not IsString($sComments) Then Return SetError($__LO_STATUS_INPUT_ERROR, 3, 0)
-		$oDocInfoCommentField.Content = $sComments
-		$iError = ($oDocInfoCommentField.Content() = $sComments) ? ($iError) : (BitOR($iError, 2))
+		$oDocInfoComment.Content = $sComments
+		$iError = ($oDocInfoComment.Content() = $sComments) ? ($iError) : (BitOR($iError, 2))
 	EndIf
 
-	If ($oDocInfoCommentField.IsFixed() = False) Then $oDocInfoCommentField.Update()
+	If ($oDocInfoComment.IsFixed() = False) Then $oDocInfoComment.Update()
 
 	Return ($iError > 0) ? (SetError($__LO_STATUS_PROP_SETTING_ERROR, $iError, 0)) : (SetError($__LO_STATUS_SUCCESS, 0, 1))
 EndFunc   ;==>_LOWriter_FieldDocInfoCommentsModify
@@ -1302,14 +1302,14 @@ EndFunc   ;==>_LOWriter_FieldDocInfoCreateAuthInsert
 ; #FUNCTION# ====================================================================================================================
 ; Name ..........: _LOWriter_FieldDocInfoCreateAuthModify
 ; Description ...: Set or Retrieve a Document Information Create Author Field's settings.
-; Syntax ........: _LOWriter_FieldDocInfoCreateAuthModify(ByRef $oDocInfoCreateAuthField[, $bIsFixed = Null[, $sAuthor = Null]])
-; Parameters ....: $oDocInfoCreateAuthField  - [in/out] an object. A Created By Author field Object from a previous _LOWriter_FieldDocInfoCreateAuthInsert or _LOWriter_FieldsDocInfoGetList function.
-;                  $bIsFixed                 - [optional] a boolean value. Default is Null. If True, the value is static, that is, the value does not update if the source changes or all fields are updated.
-;                  $sAuthor                  - [optional] a string value. Default is Null. The Author's name, note, $bIsFixed must be set to True in order for this to remain as set.
+; Syntax ........: _LOWriter_FieldDocInfoCreateAuthModify(ByRef $oDocInfoCreateAuth[, $bIsFixed = Null[, $sAuthor = Null]])
+; Parameters ....: $oDocInfoCreateAuth  - [in/out] an object. A Created By Author field Object from a previous _LOWriter_FieldDocInfoCreateAuthInsert or _LOWriter_FieldsDocInfoGetList function.
+;                  $bIsFixed            - [optional] a boolean value. Default is Null. If True, the value is static, that is, the value does not update if the source changes or all fields are updated.
+;                  $sAuthor             - [optional] a string value. Default is Null. The Author's name, note, $bIsFixed must be set to True in order for this to remain as set.
 ; Return values .: Success: 1 or Array.
 ;                  Failure: 0 and sets the @Error and @Extended flags to non-zero.
 ;                  --Input Errors--
-;                  @Error 1 @Extended 1 Return 0 = $oDocInfoCreateAuthField not an Object.
+;                  @Error 1 @Extended 1 Return 0 = $oDocInfoCreateAuth not an Object.
 ;                  @Error 1 @Extended 2 Return 0 = $bIsFixed not a Boolean.
 ;                  @Error 1 @Extended 3 Return 0 = $sAuthor not a String.
 ;                  --Property Setting Errors--
@@ -1327,33 +1327,33 @@ EndFunc   ;==>_LOWriter_FieldDocInfoCreateAuthInsert
 ; Link ..........:
 ; Example .......: Yes
 ; ===============================================================================================================================
-Func _LOWriter_FieldDocInfoCreateAuthModify(ByRef $oDocInfoCreateAuthField, $bIsFixed = Null, $sAuthor = Null)
+Func _LOWriter_FieldDocInfoCreateAuthModify(ByRef $oDocInfoCreateAuth, $bIsFixed = Null, $sAuthor = Null)
 	Local $oCOM_ErrorHandler = ObjEvent("AutoIt.Error", __LOWriter_InternalComErrorHandler)
 	#forceref $oCOM_ErrorHandler
 
 	Local $iError = 0
 	Local $avDocInfoModAuth[2]
 
-	If Not IsObj($oDocInfoCreateAuthField) Then Return SetError($__LO_STATUS_INPUT_ERROR, 1, 0)
+	If Not IsObj($oDocInfoCreateAuth) Then Return SetError($__LO_STATUS_INPUT_ERROR, 1, 0)
 
 	If __LOWriter_VarsAreNull($bIsFixed, $sAuthor) Then
-		__LOWriter_ArrayFill($avDocInfoModAuth, $oDocInfoCreateAuthField.IsFixed(), $oDocInfoCreateAuthField.Author())
+		__LOWriter_ArrayFill($avDocInfoModAuth, $oDocInfoCreateAuth.IsFixed(), $oDocInfoCreateAuth.Author())
 		Return SetError($__LO_STATUS_SUCCESS, 1, $avDocInfoModAuth)
 	EndIf
 
 	If ($bIsFixed <> Null) Then
 		If Not IsBool($bIsFixed) Then Return SetError($__LO_STATUS_INPUT_ERROR, 2, 0)
-		$oDocInfoCreateAuthField.IsFixed = $bIsFixed
-		$iError = ($oDocInfoCreateAuthField.IsFixed() = $bIsFixed) ? ($iError) : (BitOR($iError, 1))
+		$oDocInfoCreateAuth.IsFixed = $bIsFixed
+		$iError = ($oDocInfoCreateAuth.IsFixed() = $bIsFixed) ? ($iError) : (BitOR($iError, 1))
 	EndIf
 
 	If ($sAuthor <> Null) Then
 		If Not IsString($sAuthor) Then Return SetError($__LO_STATUS_INPUT_ERROR, 3, 0)
-		$oDocInfoCreateAuthField.Author = $sAuthor
-		$iError = ($oDocInfoCreateAuthField.Author() = $sAuthor) ? ($iError) : (BitOR($iError, 2))
+		$oDocInfoCreateAuth.Author = $sAuthor
+		$iError = ($oDocInfoCreateAuth.Author() = $sAuthor) ? ($iError) : (BitOR($iError, 2))
 	EndIf
 
-	If ($oDocInfoCreateAuthField.IsFixed() = False) Then $oDocInfoCreateAuthField.Update()
+	If ($oDocInfoCreateAuth.IsFixed() = False) Then $oDocInfoCreateAuth.Update()
 
 	Return ($iError > 0) ? (SetError($__LO_STATUS_PROP_SETTING_ERROR, $iError, 0)) : (SetError($__LO_STATUS_SUCCESS, 0, 1))
 EndFunc   ;==>_LOWriter_FieldDocInfoCreateAuthModify
@@ -1423,16 +1423,16 @@ EndFunc   ;==>_LOWriter_FieldDocInfoCreateDateTimeInsert
 ; #FUNCTION# ====================================================================================================================
 ; Name ..........: _LOWriter_FieldDocInfoCreateDateTimeModify
 ; Description ...: Set or Retrieve a Document Information Create Date/Time Field.
-; Syntax ........: _LOWriter_FieldDocInfoCreateDateTimeModify(ByRef $oDoc, ByRef $oDocInfoCreateDtTmField[, $bIsFixed = Null[, $iDateFormatKey = Null]])
-; Parameters ....: $oDoc                     - [in/out] an object. A Document object returned by a previous _LOWriter_DocOpen, _LOWriter_DocConnect, or _LOWriter_DocCreate function.
-;                  $oDocInfoCreateDtTmField  - [in/out] an object. A Created at Date/Time field Object from a previous _LOWriter_FieldDocInfoCreateDateTimeInsert, or _LOWriter_FieldsDocInfoGetList function.
-;                  $bIsFixed                 - [optional] a boolean value. Default is Null. If True, the value is static, that is, the value does not update if the source changes or all fields are updated.
-;                  $iDateFormatKey           - [optional] an integer value. Default is Null. A Date or Time Format Key returned from a previous _LOWriter_DateFormatKeyCreate or _LOWriter_DateFormatKeyList function.
+; Syntax ........: _LOWriter_FieldDocInfoCreateDateTimeModify(ByRef $oDoc, ByRef $oDocInfoCreateDtTm[, $bIsFixed = Null[, $iDateFormatKey = Null]])
+; Parameters ....: $oDoc                - [in/out] an object. A Document object returned by a previous _LOWriter_DocOpen, _LOWriter_DocConnect, or _LOWriter_DocCreate function.
+;                  $oDocInfoCreateDtTm  - [in/out] an object. A Created at Date/Time field Object from a previous _LOWriter_FieldDocInfoCreateDateTimeInsert, or _LOWriter_FieldsDocInfoGetList function.
+;                  $bIsFixed            - [optional] a boolean value. Default is Null. If True, the value is static, that is, the value does not update if the source changes or all fields are updated.
+;                  $iDateFormatKey      - [optional] an integer value. Default is Null. A Date or Time Format Key returned from a previous _LOWriter_DateFormatKeyCreate or _LOWriter_DateFormatKeyList function.
 ; Return values .: Success: 1 or Array.
 ;                  Failure: 0 and sets the @Error and @Extended flags to non-zero.
 ;                  --Input Errors--
 ;                  @Error 1 @Extended 1 Return 0 = $oDoc not an Object.
-;                  @Error 1 @Extended 2 Return 0 = $oDocInfoCreateDtTmField not an Object.
+;                  @Error 1 @Extended 2 Return 0 = $oDocInfoCreateDtTm not an Object.
 ;                  @Error 1 @Extended 3 Return 0 = $bIsFixed not a Boolean.
 ;                  @Error 1 @Extended 4 Return 0 = $iDateFormatKey not an Integer.
 ;                  @Error 1 @Extended 5 Return 0 = $iDateFormatKey not found in document.
@@ -1451,7 +1451,7 @@ EndFunc   ;==>_LOWriter_FieldDocInfoCreateDateTimeInsert
 ; Link ..........:
 ; Example .......: Yes
 ; ===============================================================================================================================
-Func _LOWriter_FieldDocInfoCreateDateTimeModify(ByRef $oDoc, ByRef $oDocInfoCreateDtTmField, $bIsFixed = Null, $iDateFormatKey = Null)
+Func _LOWriter_FieldDocInfoCreateDateTimeModify(ByRef $oDoc, ByRef $oDocInfoCreateDtTm, $bIsFixed = Null, $iDateFormatKey = Null)
 	Local $oCOM_ErrorHandler = ObjEvent("AutoIt.Error", __LOWriter_InternalComErrorHandler)
 	#forceref $oCOM_ErrorHandler
 
@@ -1459,33 +1459,33 @@ Func _LOWriter_FieldDocInfoCreateDateTimeModify(ByRef $oDoc, ByRef $oDocInfoCrea
 	Local $avDocInfoCrtDate[2]
 
 	If Not IsObj($oDoc) Then Return SetError($__LO_STATUS_INPUT_ERROR, 1, 0)
-	If Not IsObj($oDocInfoCreateDtTmField) Then Return SetError($__LO_STATUS_INPUT_ERROR, 2, 0)
+	If Not IsObj($oDocInfoCreateDtTm) Then Return SetError($__LO_STATUS_INPUT_ERROR, 2, 0)
 
 	If __LOWriter_VarsAreNull($bIsFixed, $iDateFormatKey) Then
 		; Libre Office Seems to insert its Number formats by adding 10,000 to the number, but if I insert that same value, it
 		; fails/causes the wrong format to be used, so, If the Number format is greater than or equal to 10,000, Minus 10,000 from
 		; the value.
-		$iNumberFormat = $oDocInfoCreateDtTmField.NumberFormat()
+		$iNumberFormat = $oDocInfoCreateDtTm.NumberFormat()
 		$iNumberFormat = ($iNumberFormat >= 10000) ? ($iNumberFormat - 10000) : ($iNumberFormat)
 
-		__LOWriter_ArrayFill($avDocInfoCrtDate, $oDocInfoCreateDtTmField.IsFixed(), $iNumberFormat)
+		__LOWriter_ArrayFill($avDocInfoCrtDate, $oDocInfoCreateDtTm.IsFixed(), $iNumberFormat)
 		Return SetError($__LO_STATUS_SUCCESS, 1, $avDocInfoCrtDate)
 	EndIf
 
 	If ($bIsFixed <> Null) Then
 		If Not IsBool($bIsFixed) Then Return SetError($__LO_STATUS_INPUT_ERROR, 3, 0)
-		$oDocInfoCreateDtTmField.IsFixed = $bIsFixed
-		$iError = ($oDocInfoCreateDtTmField.IsFixed() = $bIsFixed) ? ($iError) : (BitOR($iError, 1))
+		$oDocInfoCreateDtTm.IsFixed = $bIsFixed
+		$iError = ($oDocInfoCreateDtTm.IsFixed() = $bIsFixed) ? ($iError) : (BitOR($iError, 1))
 	EndIf
 
 	If ($iDateFormatKey <> Null) Then
 		If Not IsInt($iDateFormatKey) Then Return SetError($__LO_STATUS_INPUT_ERROR, 4, 0)
 		If Not _LOWriter_DateFormatKeyExists($oDoc, $iDateFormatKey) Then Return SetError($__LO_STATUS_INPUT_ERROR, 5, 0)
-		$oDocInfoCreateDtTmField.NumberFormat = $iDateFormatKey
-		$iError = ($oDocInfoCreateDtTmField.NumberFormat() = $iDateFormatKey) ? ($iError) : (BitOR($iError, 2))
+		$oDocInfoCreateDtTm.NumberFormat = $iDateFormatKey
+		$iError = ($oDocInfoCreateDtTm.NumberFormat() = $iDateFormatKey) ? ($iError) : (BitOR($iError, 2))
 	EndIf
 
-	If ($oDocInfoCreateDtTmField.IsFixed() = False) Then $oDocInfoCreateDtTmField.Update()
+	If ($oDocInfoCreateDtTm.IsFixed() = False) Then $oDocInfoCreateDtTm.Update()
 
 	Return ($iError > 0) ? (SetError($__LO_STATUS_PROP_SETTING_ERROR, $iError, 0)) : (SetError($__LO_STATUS_SUCCESS, 0, 1))
 EndFunc   ;==>_LOWriter_FieldDocInfoCreateDateTimeModify
@@ -1555,14 +1555,14 @@ EndFunc   ;==>_LOWriter_FieldDocInfoEditTimeInsert
 ; #FUNCTION# ====================================================================================================================
 ; Name ..........: _LOWriter_FieldDocInfoEditTimeModify
 ; Description ...: Set or Retrieve a Document Information Total Editing Time Field's settings.
-; Syntax ........: _LOWriter_FieldDocInfoEditTimeModify(ByRef $oDocInfoEditTimeField[, $bIsFixed = Null[, $iTimeFormatKey = Null]])
-; Parameters ....: $oDocInfoEditTimeField - [in/out] an object. A Doc Info Total Editing Time field Object from a previous _LOWriter_FieldDocInfoEditTimeInsert, or _LOWriter_FieldsDocInfoGetList function.
-;                  $bIsFixed              - [optional] a boolean value. Default is Null. If True, the value is static, that is, the value does not update if the source changes or all fields are updated.
-;                  $iTimeFormatKey        - [optional] an integer value. Default is Null. A Time Format Key returned from a previous _LOWriter_DateFormatKeyCreate or _LOWriter_DateFormatKeyList function.
+; Syntax ........: _LOWriter_FieldDocInfoEditTimeModify(ByRef $oDocInfoEditTime[, $bIsFixed = Null[, $iTimeFormatKey = Null]])
+; Parameters ....: $oDocInfoEditTime    - [in/out] an object. A Doc Info Total Editing Time field Object from a previous _LOWriter_FieldDocInfoEditTimeInsert, or _LOWriter_FieldsDocInfoGetList function.
+;                  $bIsFixed            - [optional] a boolean value. Default is Null. If True, the value is static, that is, the value does not update if the source changes or all fields are updated.
+;                  $iTimeFormatKey      - [optional] an integer value. Default is Null. A Time Format Key returned from a previous _LOWriter_DateFormatKeyCreate or _LOWriter_DateFormatKeyList function.
 ; Return values .: Success: 1 or Array.
 ;                  Failure: 0 and sets the @Error and @Extended flags to non-zero.
 ;                  --Input Errors--
-;                  @Error 1 @Extended 1 Return 0 = $oDocInfoEditTimeField not an Object.
+;                  @Error 1 @Extended 1 Return 0 = $oDocInfoEditTime not an Object.
 ;                  @Error 1 @Extended 2 Return 0 = $bIsFixed not a Boolean.
 ;                  @Error 1 @Extended 3 Return 0 = $iTimeFormatKey not an Integer.
 ;                  @Error 1 @Extended 4 Return 0 = $iTimeFormatKey not found in document.
@@ -1581,40 +1581,40 @@ EndFunc   ;==>_LOWriter_FieldDocInfoEditTimeInsert
 ; Link ..........:
 ; Example .......: Yes
 ; ===============================================================================================================================
-Func _LOWriter_FieldDocInfoEditTimeModify(ByRef $oDocInfoEditTimeField, $bIsFixed = Null, $iTimeFormatKey = Null)
+Func _LOWriter_FieldDocInfoEditTimeModify(ByRef $oDocInfoEditTime, $bIsFixed = Null, $iTimeFormatKey = Null)
 	Local $oCOM_ErrorHandler = ObjEvent("AutoIt.Error", __LOWriter_InternalComErrorHandler)
 	#forceref $oCOM_ErrorHandler
 
 	Local $iError = 0, $iNumberFormat
 	Local $avDocInfoEditTm[2]
 
-	If Not IsObj($oDocInfoEditTimeField) Then Return SetError($__LO_STATUS_INPUT_ERROR, 1, 0)
+	If Not IsObj($oDocInfoEditTime) Then Return SetError($__LO_STATUS_INPUT_ERROR, 1, 0)
 
 	If __LOWriter_VarsAreNull($bIsFixed, $iTimeFormatKey) Then
 		; Libre Office Seems to insert its Number formats by adding 10,000 to the number, but if I insert that same value, it
 		; fails/causes the wrong format to be used, so, If the Number format is greater than or equal to 10,000, Minus 10,000
 		; from the value.
-		$iNumberFormat = $oDocInfoEditTimeField.NumberFormat()
+		$iNumberFormat = $oDocInfoEditTime.NumberFormat()
 		$iNumberFormat = ($iNumberFormat >= 10000) ? ($iNumberFormat - 10000) : ($iNumberFormat)
 
-		__LOWriter_ArrayFill($avDocInfoEditTm, $oDocInfoEditTimeField.IsFixed(), $iNumberFormat)
+		__LOWriter_ArrayFill($avDocInfoEditTm, $oDocInfoEditTime.IsFixed(), $iNumberFormat)
 		Return SetError($__LO_STATUS_SUCCESS, 1, $avDocInfoEditTm)
 	EndIf
 
 	If ($bIsFixed <> Null) Then
 		If Not IsBool($bIsFixed) Then Return SetError($__LO_STATUS_INPUT_ERROR, 2, 0)
-		$oDocInfoEditTimeField.IsFixed = $bIsFixed
-		$iError = ($oDocInfoEditTimeField.IsFixed() = $bIsFixed) ? ($iError) : (BitOR($iError, 1))
+		$oDocInfoEditTime.IsFixed = $bIsFixed
+		$iError = ($oDocInfoEditTime.IsFixed() = $bIsFixed) ? ($iError) : (BitOR($iError, 1))
 	EndIf
 
 	If ($iTimeFormatKey <> Null) Then
 		If Not IsInt($iTimeFormatKey) Then Return SetError($__LO_STATUS_INPUT_ERROR, 3, 0)
 		If Not IsInt($iTimeFormatKey) Then Return SetError($__LO_STATUS_INPUT_ERROR, 4, 0)
-		$oDocInfoEditTimeField.NumberFormat = $iTimeFormatKey
-		$iError = ($oDocInfoEditTimeField.NumberFormat() = $iTimeFormatKey) ? ($iError) : (BitOR($iError, 2))
+		$oDocInfoEditTime.NumberFormat = $iTimeFormatKey
+		$iError = ($oDocInfoEditTime.NumberFormat() = $iTimeFormatKey) ? ($iError) : (BitOR($iError, 2))
 	EndIf
 
-	If ($oDocInfoEditTimeField.IsFixed() = False) Then $oDocInfoEditTimeField.Update()
+	If ($oDocInfoEditTime.IsFixed() = False) Then $oDocInfoEditTime.Update()
 
 	Return ($iError > 0) ? (SetError($__LO_STATUS_PROP_SETTING_ERROR, $iError, 0)) : (SetError($__LO_STATUS_SUCCESS, 0, 1))
 EndFunc   ;==>_LOWriter_FieldDocInfoEditTimeModify
@@ -1686,14 +1686,14 @@ EndFunc   ;==>_LOWriter_FieldDocInfoKeywordsInsert
 ; #FUNCTION# ====================================================================================================================
 ; Name ..........: _LOWriter_FieldDocInfoKeywordsModify
 ; Description ...: Set or Retrieve a Document Information Keywords Field's settings.
-; Syntax ........: _LOWriter_FieldDocInfoKeywordsModify(ByRef $oDocInfoKeywordField[, $bIsFixed = Null[, $sKeywords = Null]])
-; Parameters ....: $oDocInfoKeywordField  - [in/out] an object. A Doc Info Keywords field Object from a previous _LOWriter_FieldDocInfoKeywordsInsert, or _LOWriter_FieldsDocInfoGetList function.
-;                  $bIsFixed              - [optional] a boolean value. Default is Null. If True, the value is static, that is, the value does not update if the source changes or all fields are updated.
-;                  $sKeywords             - [optional] a string value. Default is Null. The Keywords text to display, note, $bIsFixed must be True for this to be displayed.
+; Syntax ........: _LOWriter_FieldDocInfoKeywordsModify(ByRef $oDocInfoKeyword[, $bIsFixed = Null[, $sKeywords = Null]])
+; Parameters ....: $oDocInfoKeyword     - [in/out] an object. A Doc Info Keywords field Object from a previous _LOWriter_FieldDocInfoKeywordsInsert, or _LOWriter_FieldsDocInfoGetList function.
+;                  $bIsFixed            - [optional] a boolean value. Default is Null. If True, the value is static, that is, the value does not update if the source changes or all fields are updated.
+;                  $sKeywords           - [optional] a string value. Default is Null. The Keywords text to display, note, $bIsFixed must be True for this to be displayed.
 ; Return values .: Success: 1 or Array.
 ;                  Failure: 0 and sets the @Error and @Extended flags to non-zero.
 ;                  --Input Errors--
-;                  @Error 1 @Extended 1 Return 0 = $oDocInfoKeywordField not an Object.
+;                  @Error 1 @Extended 1 Return 0 = $oDocInfoKeyword not an Object.
 ;                  @Error 1 @Extended 2 Return 0 = $bIsFixed not a Boolean.
 ;                  @Error 1 @Extended 3 Return 0 = $sKeywords not a String.
 ;                  --Property Setting Errors--
@@ -1711,33 +1711,33 @@ EndFunc   ;==>_LOWriter_FieldDocInfoKeywordsInsert
 ; Link ..........:
 ; Example .......: Yes
 ; ===============================================================================================================================
-Func _LOWriter_FieldDocInfoKeywordsModify(ByRef $oDocInfoKeywordField, $bIsFixed = Null, $sKeywords = Null)
+Func _LOWriter_FieldDocInfoKeywordsModify(ByRef $oDocInfoKeyword, $bIsFixed = Null, $sKeywords = Null)
 	Local $oCOM_ErrorHandler = ObjEvent("AutoIt.Error", __LOWriter_InternalComErrorHandler)
 	#forceref $oCOM_ErrorHandler
 
 	Local $iError = 0
 	Local $avDocInfoKyWrd[2]
 
-	If Not IsObj($oDocInfoKeywordField) Then Return SetError($__LO_STATUS_INPUT_ERROR, 1, 0)
+	If Not IsObj($oDocInfoKeyword) Then Return SetError($__LO_STATUS_INPUT_ERROR, 1, 0)
 
 	If __LOWriter_VarsAreNull($bIsFixed, $sKeywords) Then
-		__LOWriter_ArrayFill($avDocInfoKyWrd, $oDocInfoKeywordField.IsFixed(), $oDocInfoKeywordField.Content())
+		__LOWriter_ArrayFill($avDocInfoKyWrd, $oDocInfoKeyword.IsFixed(), $oDocInfoKeyword.Content())
 		Return SetError($__LO_STATUS_SUCCESS, 1, $avDocInfoKyWrd)
 	EndIf
 
 	If ($bIsFixed <> Null) Then
 		If Not IsBool($bIsFixed) Then Return SetError($__LO_STATUS_INPUT_ERROR, 2, 0)
-		$oDocInfoKeywordField.IsFixed = $bIsFixed
-		$iError = ($oDocInfoKeywordField.IsFixed() = $bIsFixed) ? ($iError) : (BitOR($iError, 1))
+		$oDocInfoKeyword.IsFixed = $bIsFixed
+		$iError = ($oDocInfoKeyword.IsFixed() = $bIsFixed) ? ($iError) : (BitOR($iError, 1))
 	EndIf
 
 	If ($sKeywords <> Null) Then
 		If Not IsString($sKeywords) Then Return SetError($__LO_STATUS_INPUT_ERROR, 3, 0)
-		$oDocInfoKeywordField.Content = $sKeywords
-		$iError = ($oDocInfoKeywordField.Content() = $sKeywords) ? ($iError) : (BitOR($iError, 2))
+		$oDocInfoKeyword.Content = $sKeywords
+		$iError = ($oDocInfoKeyword.Content() = $sKeywords) ? ($iError) : (BitOR($iError, 2))
 	EndIf
 
-	If ($oDocInfoKeywordField.IsFixed() = False) Then $oDocInfoKeywordField.Update()
+	If ($oDocInfoKeyword.IsFixed() = False) Then $oDocInfoKeyword.Update()
 
 	Return ($iError > 0) ? (SetError($__LO_STATUS_PROP_SETTING_ERROR, $iError, 0)) : (SetError($__LO_STATUS_SUCCESS, 0, 1))
 EndFunc   ;==>_LOWriter_FieldDocInfoKeywordsModify
@@ -1809,14 +1809,14 @@ EndFunc   ;==>_LOWriter_FieldDocInfoModAuthInsert
 ; #FUNCTION# ====================================================================================================================
 ; Name ..........: _LOWriter_FieldDocInfoModAuthModify
 ; Description ...: Set or Retrieve a Document Information Modification Author Field's settings.
-; Syntax ........: _LOWriter_FieldDocInfoModAuthModify(ByRef $oDocInfoModAuthField[, $bIsFixed = Null[, $sAuthor = Null]])
-; Parameters ....: $oDocInfoModAuthField  - [in/out] an object. A Modified By Author field Object from a previous _LOWriter_FieldDocInfoModAuthInsert, or _LOWriter_FieldsDocInfoGetList function.
-;                  $bIsFixed              - [optional] a boolean value. Default is Null. If True, the value is static, that is, the value does not update if the source changes or all fields are updated.
-;                  $sAuthor               - [optional] a string value. Default is Null. The Author's name, note, $bIsFixed must be set to True in order for this to remain as set.
+; Syntax ........: _LOWriter_FieldDocInfoModAuthModify(ByRef $oDocInfoModAuth[, $bIsFixed = Null[, $sAuthor = Null]])
+; Parameters ....: $oDocInfoModAuth     - [in/out] an object. A Modified By Author field Object from a previous _LOWriter_FieldDocInfoModAuthInsert, or _LOWriter_FieldsDocInfoGetList function.
+;                  $bIsFixed            - [optional] a boolean value. Default is Null. If True, the value is static, that is, the value does not update if the source changes or all fields are updated.
+;                  $sAuthor             - [optional] a string value. Default is Null. The Author's name, note, $bIsFixed must be set to True in order for this to remain as set.
 ; Return values .: Success: 1 or Array.
 ;                  Failure: 0 and sets the @Error and @Extended flags to non-zero.
 ;                  --Input Errors--
-;                  @Error 1 @Extended 1 Return 0 = $oDocInfoModAuthField not an Object.
+;                  @Error 1 @Extended 1 Return 0 = $oDocInfoModAuth not an Object.
 ;                  @Error 1 @Extended 2 Return 0 = $bIsFixed not a Boolean.
 ;                  @Error 1 @Extended 3 Return 0 = $sAuthor not a String.
 ;                  --Property Setting Errors--
@@ -1834,33 +1834,33 @@ EndFunc   ;==>_LOWriter_FieldDocInfoModAuthInsert
 ; Link ..........:
 ; Example .......: Yes
 ; ===============================================================================================================================
-Func _LOWriter_FieldDocInfoModAuthModify(ByRef $oDocInfoModAuthField, $bIsFixed = Null, $sAuthor = Null)
+Func _LOWriter_FieldDocInfoModAuthModify(ByRef $oDocInfoModAuth, $bIsFixed = Null, $sAuthor = Null)
 	Local $oCOM_ErrorHandler = ObjEvent("AutoIt.Error", __LOWriter_InternalComErrorHandler)
 	#forceref $oCOM_ErrorHandler
 
 	Local $iError = 0
 	Local $avDocInfoModAuth[2]
 
-	If Not IsObj($oDocInfoModAuthField) Then Return SetError($__LO_STATUS_INPUT_ERROR, 1, 0)
+	If Not IsObj($oDocInfoModAuth) Then Return SetError($__LO_STATUS_INPUT_ERROR, 1, 0)
 
 	If __LOWriter_VarsAreNull($bIsFixed, $sAuthor) Then
-		__LOWriter_ArrayFill($avDocInfoModAuth, $oDocInfoModAuthField.IsFixed(), $oDocInfoModAuthField.Author())
+		__LOWriter_ArrayFill($avDocInfoModAuth, $oDocInfoModAuth.IsFixed(), $oDocInfoModAuth.Author())
 		Return SetError($__LO_STATUS_SUCCESS, 1, $avDocInfoModAuth)
 	EndIf
 
 	If ($bIsFixed <> Null) Then
 		If Not IsBool($bIsFixed) Then Return SetError($__LO_STATUS_INPUT_ERROR, 2, 0)
-		$oDocInfoModAuthField.IsFixed = $bIsFixed
-		$iError = ($oDocInfoModAuthField.IsFixed() = $bIsFixed) ? ($iError) : (BitOR($iError, 1))
+		$oDocInfoModAuth.IsFixed = $bIsFixed
+		$iError = ($oDocInfoModAuth.IsFixed() = $bIsFixed) ? ($iError) : (BitOR($iError, 1))
 	EndIf
 
 	If ($sAuthor <> Null) Then
 		If Not IsString($sAuthor) Then Return SetError($__LO_STATUS_INPUT_ERROR, 3, 0)
-		$oDocInfoModAuthField.Author = $sAuthor
-		$iError = ($oDocInfoModAuthField.Author() = $sAuthor) ? ($iError) : (BitOR($iError, 2))
+		$oDocInfoModAuth.Author = $sAuthor
+		$iError = ($oDocInfoModAuth.Author() = $sAuthor) ? ($iError) : (BitOR($iError, 2))
 	EndIf
 
-	If ($oDocInfoModAuthField.IsFixed() = False) Then $oDocInfoModAuthField.Update()
+	If ($oDocInfoModAuth.IsFixed() = False) Then $oDocInfoModAuth.Update()
 
 	Return ($iError > 0) ? (SetError($__LO_STATUS_PROP_SETTING_ERROR, $iError, 0)) : (SetError($__LO_STATUS_SUCCESS, 0, 1))
 EndFunc   ;==>_LOWriter_FieldDocInfoModAuthModify
@@ -1930,11 +1930,11 @@ EndFunc   ;==>_LOWriter_FieldDocInfoModDateTimeInsert
 ; #FUNCTION# ====================================================================================================================
 ; Name ..........: _LOWriter_FieldDocInfoModDateTimeModify
 ; Description ...: Set or Retrieve a Document Information Modification Date/Time Field.
-; Syntax ........: _LOWriter_FieldDocInfoModDateTimeModify(ByRef $oDoc, ByRef $oDocInfoModDtTmField[, $bIsFixed = Null[, $iDateFormatKey = Null]])
-; Parameters ....: $oDoc                  - [in/out] an object. A Document object returned by a previous _LOWriter_DocOpen, _LOWriter_DocConnect, or _LOWriter_DocCreate function.
-;                  $oDocInfoModDtTmField  - [in/out] an object. A Modified at Date/Time field Object from a previous _LOWriter_FieldDocInfoModDateTimeInsert, or _LOWriter_FieldsDocInfoGetList function.
-;                  $bIsFixed              - [optional] a boolean value. Default is Null. If True, the value is static, that is, the value does not update if the source changes or all fields are updated.
-;                  $iDateFormatKey        - [optional] an integer value. Default is Null. A Date or Time Format Key returned from a previous _LOWriter_DateFormatKeyCreate or _LOWriter_DateFormatKeyList function.
+; Syntax ........: _LOWriter_FieldDocInfoModDateTimeModify(ByRef $oDoc, ByRef $oDocInfoModDtTm[, $bIsFixed = Null[, $iDateFormatKey = Null]])
+; Parameters ....: $oDoc                - [in/out] an object. A Document object returned by a previous _LOWriter_DocOpen, _LOWriter_DocConnect, or _LOWriter_DocCreate function.
+;                  $oDocInfoModDtTm     - [in/out] an object. A Modified at Date/Time field Object from a previous _LOWriter_FieldDocInfoModDateTimeInsert, or _LOWriter_FieldsDocInfoGetList function.
+;                  $bIsFixed            - [optional] a boolean value. Default is Null. If True, the value is static, that is, the value does not update if the source changes or all fields are updated.
+;                  $iDateFormatKey      - [optional] an integer value. Default is Null. A Date or Time Format Key returned from a previous _LOWriter_DateFormatKeyCreate or _LOWriter_DateFormatKeyList function.
 ; Return values .: Success: 1 or Array.
 ;                  Failure: 0 and sets the @Error and @Extended flags to non-zero.
 ;                  --Input Errors--
@@ -1958,7 +1958,7 @@ EndFunc   ;==>_LOWriter_FieldDocInfoModDateTimeInsert
 ; Link ..........:
 ; Example .......: Yes
 ; ===============================================================================================================================
-Func _LOWriter_FieldDocInfoModDateTimeModify(ByRef $oDoc, ByRef $oDocInfoModDtTmField, $bIsFixed = Null, $iDateFormatKey = Null)
+Func _LOWriter_FieldDocInfoModDateTimeModify(ByRef $oDoc, ByRef $oDocInfoModDtTm, $bIsFixed = Null, $iDateFormatKey = Null)
 	Local $oCOM_ErrorHandler = ObjEvent("AutoIt.Error", __LOWriter_InternalComErrorHandler)
 	#forceref $oCOM_ErrorHandler
 
@@ -1966,33 +1966,33 @@ Func _LOWriter_FieldDocInfoModDateTimeModify(ByRef $oDoc, ByRef $oDocInfoModDtTm
 	Local $avDocInfoModDate[2]
 
 	If Not IsObj($oDoc) Then Return SetError($__LO_STATUS_INPUT_ERROR, 1, 0)
-	If Not IsObj($oDocInfoModDtTmField) Then Return SetError($__LO_STATUS_INPUT_ERROR, 2, 0)
+	If Not IsObj($oDocInfoModDtTm) Then Return SetError($__LO_STATUS_INPUT_ERROR, 2, 0)
 
 	If __LOWriter_VarsAreNull($bIsFixed, $iDateFormatKey) Then
 		; Libre Office Seems to insert its Number formats by adding 10,000 to the number, but if I insert that same value, it
 		; fails/causes the wrong format to be used, so, If the Number format is greater than or equal to 10,000, Minus 10,000
 		; from the value.
-		$iNumberFormat = $oDocInfoModDtTmField.NumberFormat()
+		$iNumberFormat = $oDocInfoModDtTm.NumberFormat()
 		$iNumberFormat = ($iNumberFormat >= 10000) ? ($iNumberFormat - 10000) : ($iNumberFormat)
 
-		__LOWriter_ArrayFill($avDocInfoModDate, $oDocInfoModDtTmField.IsFixed(), $iNumberFormat)
+		__LOWriter_ArrayFill($avDocInfoModDate, $oDocInfoModDtTm.IsFixed(), $iNumberFormat)
 		Return SetError($__LO_STATUS_SUCCESS, 1, $avDocInfoModDate)
 	EndIf
 
 	If ($bIsFixed <> Null) Then
 		If Not IsBool($bIsFixed) Then Return SetError($__LO_STATUS_INPUT_ERROR, 3, 0)
-		$oDocInfoModDtTmField.IsFixed = $bIsFixed
-		$iError = ($oDocInfoModDtTmField.IsFixed() = $bIsFixed) ? ($iError) : (BitOR($iError, 1))
+		$oDocInfoModDtTm.IsFixed = $bIsFixed
+		$iError = ($oDocInfoModDtTm.IsFixed() = $bIsFixed) ? ($iError) : (BitOR($iError, 1))
 	EndIf
 
 	If ($iDateFormatKey <> Null) Then
 		If Not IsInt($iDateFormatKey) Then Return SetError($__LO_STATUS_INPUT_ERROR, 4, 0)
 		If Not _LOWriter_DateFormatKeyExists($oDoc, $iDateFormatKey) Then Return SetError($__LO_STATUS_INPUT_ERROR, 5, 0)
-		$oDocInfoModDtTmField.NumberFormat = $iDateFormatKey
-		$iError = ($oDocInfoModDtTmField.NumberFormat() = $iDateFormatKey) ? ($iError) : (BitOR($iError, 2))
+		$oDocInfoModDtTm.NumberFormat = $iDateFormatKey
+		$iError = ($oDocInfoModDtTm.NumberFormat() = $iDateFormatKey) ? ($iError) : (BitOR($iError, 2))
 	EndIf
 
-	If ($oDocInfoModDtTmField.IsFixed() = False) Then $oDocInfoModDtTmField.Update()
+	If ($oDocInfoModDtTm.IsFixed() = False) Then $oDocInfoModDtTm.Update()
 
 	Return ($iError > 0) ? (SetError($__LO_STATUS_PROP_SETTING_ERROR, $iError, 0)) : (SetError($__LO_STATUS_SUCCESS, 0, 1))
 EndFunc   ;==>_LOWriter_FieldDocInfoModDateTimeModify
@@ -2064,14 +2064,14 @@ EndFunc   ;==>_LOWriter_FieldDocInfoPrintAuthInsert
 ; #FUNCTION# ====================================================================================================================
 ; Name ..........: _LOWriter_FieldDocInfoPrintAuthModify
 ; Description ...: Set or Retrieve a Document Information Last Print Author Field's settings.
-; Syntax ........: _LOWriter_FieldDocInfoPrintAuthModify(ByRef $oDocInfoPrintAuthField[, $bIsFixed = Null[, $sAuthor = Null]])
-; Parameters ....: $oDocInfoPrintAuthField  - [in/out] an object. A Printed By Author field Object from a previous _LOWriter_FieldDocInfoPrintAuthInsert, or _LOWriter_FieldsDocInfoGetList function.
-;                  $bIsFixed                - [optional] a boolean value. Default is Null. If True, the value is static, that is, the value does not update if the source changes or all fields are updated.
-;                  $sAuthor                 - [optional] a string value. Default is Null. The Author's name, note, $bIsFixed must be set to True in order for this to remain as set.
+; Syntax ........: _LOWriter_FieldDocInfoPrintAuthModify(ByRef $oDocInfoPrintAuth[, $bIsFixed = Null[, $sAuthor = Null]])
+; Parameters ....: $oDocInfoPrintAuth   - [in/out] an object. A Printed By Author field Object from a previous _LOWriter_FieldDocInfoPrintAuthInsert, or _LOWriter_FieldsDocInfoGetList function.
+;                  $bIsFixed            - [optional] a boolean value. Default is Null. If True, the value is static, that is, the value does not update if the source changes or all fields are updated.
+;                  $sAuthor             - [optional] a string value. Default is Null. The Author's name, note, $bIsFixed must be set to True in order for this to remain as set.
 ; Return values .: Success: 1 or Array.
 ;                  Failure: 0 and sets the @Error and @Extended flags to non-zero.
 ;                  --Input Errors--
-;                  @Error 1 @Extended 1 Return 0 = $oDocInfoPrintAuthField not an Object.
+;                  @Error 1 @Extended 1 Return 0 = $oDocInfoPrintAuth not an Object.
 ;                  @Error 1 @Extended 2 Return 0 = $bIsFixed not a Boolean.
 ;                  @Error 1 @Extended 3 Return 0 = $sAuthor not a String.
 ;                  --Property Setting Errors--
@@ -2089,33 +2089,33 @@ EndFunc   ;==>_LOWriter_FieldDocInfoPrintAuthInsert
 ; Link ..........:
 ; Example .......: Yes
 ; ===============================================================================================================================
-Func _LOWriter_FieldDocInfoPrintAuthModify(ByRef $oDocInfoPrintAuthField, $bIsFixed = Null, $sAuthor = Null)
+Func _LOWriter_FieldDocInfoPrintAuthModify(ByRef $oDocInfoPrintAuth, $bIsFixed = Null, $sAuthor = Null)
 	Local $oCOM_ErrorHandler = ObjEvent("AutoIt.Error", __LOWriter_InternalComErrorHandler)
 	#forceref $oCOM_ErrorHandler
 
 	Local $iError = 0
 	Local $avDocInfoModAuth[2]
 
-	If Not IsObj($oDocInfoPrintAuthField) Then Return SetError($__LO_STATUS_INPUT_ERROR, 1, 0)
+	If Not IsObj($oDocInfoPrintAuth) Then Return SetError($__LO_STATUS_INPUT_ERROR, 1, 0)
 
 	If __LOWriter_VarsAreNull($bIsFixed, $sAuthor) Then
-		__LOWriter_ArrayFill($avDocInfoModAuth, $oDocInfoPrintAuthField.IsFixed(), $oDocInfoPrintAuthField.Author())
+		__LOWriter_ArrayFill($avDocInfoModAuth, $oDocInfoPrintAuth.IsFixed(), $oDocInfoPrintAuth.Author())
 		Return SetError($__LO_STATUS_SUCCESS, 1, $avDocInfoModAuth)
 	EndIf
 
 	If ($bIsFixed <> Null) Then
 		If Not IsBool($bIsFixed) Then Return SetError($__LO_STATUS_INPUT_ERROR, 2, 0)
-		$oDocInfoPrintAuthField.IsFixed = $bIsFixed
-		$iError = ($oDocInfoPrintAuthField.IsFixed() = $bIsFixed) ? ($iError) : (BitOR($iError, 1))
+		$oDocInfoPrintAuth.IsFixed = $bIsFixed
+		$iError = ($oDocInfoPrintAuth.IsFixed() = $bIsFixed) ? ($iError) : (BitOR($iError, 1))
 	EndIf
 
 	If ($sAuthor <> Null) Then
 		If Not IsString($sAuthor) Then Return SetError($__LO_STATUS_INPUT_ERROR, 3, 0)
-		$oDocInfoPrintAuthField.Author = $sAuthor
-		$iError = ($oDocInfoPrintAuthField.Author() = $sAuthor) ? ($iError) : (BitOR($iError, 2))
+		$oDocInfoPrintAuth.Author = $sAuthor
+		$iError = ($oDocInfoPrintAuth.Author() = $sAuthor) ? ($iError) : (BitOR($iError, 2))
 	EndIf
 
-	If ($oDocInfoPrintAuthField.IsFixed() = False) Then $oDocInfoPrintAuthField.Update()
+	If ($oDocInfoPrintAuth.IsFixed() = False) Then $oDocInfoPrintAuth.Update()
 
 	Return ($iError > 0) ? (SetError($__LO_STATUS_PROP_SETTING_ERROR, $iError, 0)) : (SetError($__LO_STATUS_SUCCESS, 0, 1))
 EndFunc   ;==>_LOWriter_FieldDocInfoPrintAuthModify
@@ -2185,16 +2185,16 @@ EndFunc   ;==>_LOWriter_FieldDocInfoPrintDateTimeInsert
 ; #FUNCTION# ====================================================================================================================
 ; Name ..........: _LOWriter_FieldDocInfoPrintDateTimeModify
 ; Description ...: Set or Retrieve a Document Information Last Print Date/Time Field.
-; Syntax ........: _LOWriter_FieldDocInfoPrintDateTimeModify(ByRef $oDoc, ByRef $oDocInfoPrintDtTmField[, $bIsFixed = Null[, $iDateFormatKey = Null]])
-; Parameters ....: $oDoc                    - [in/out] an object. A Document object returned by a previous _LOWriter_DocOpen, _LOWriter_DocConnect, or _LOWriter_DocCreate function.
-;                  $oDocInfoPrintDtTmField  - [in/out] an object. A Printed at Date/Time field Object from a previous _LOWriter_FieldDocInfoPrintDateTimeInsert, or _LOWriter_FieldsDocInfoGetList function.
-;                  $bIsFixed                - [optional] a boolean value. Default is Null. If True, the value is static, that is, the value does not update if the source changes or all fields are updated.
-;                  $iDateFormatKey          - [optional] an integer value. Default is Null. A Date or Time Format Key returned from a previous _LOWriter_DateFormatKeyCreate or _LOWriter_DateFormatKeyList function.
+; Syntax ........: _LOWriter_FieldDocInfoPrintDateTimeModify(ByRef $oDoc, ByRef $oDocInfoPrintDtTm[, $bIsFixed = Null[, $iDateFormatKey = Null]])
+; Parameters ....: $oDoc                - [in/out] an object. A Document object returned by a previous _LOWriter_DocOpen, _LOWriter_DocConnect, or _LOWriter_DocCreate function.
+;                  $oDocInfoPrintDtTm   - [in/out] an object. A Printed at Date/Time field Object from a previous _LOWriter_FieldDocInfoPrintDateTimeInsert, or _LOWriter_FieldsDocInfoGetList function.
+;                  $bIsFixed            - [optional] a boolean value. Default is Null. If True, the value is static, that is, the value does not update if the source changes or all fields are updated.
+;                  $iDateFormatKey      - [optional] an integer value. Default is Null. A Date or Time Format Key returned from a previous _LOWriter_DateFormatKeyCreate or _LOWriter_DateFormatKeyList function.
 ; Return values .: Success: 1 or Array.
 ;                  Failure: 0 and sets the @Error and @Extended flags to non-zero.
 ;                  --Input Errors--
 ;                  @Error 1 @Extended 1 Return 0 = $oDoc not an Object.
-;                  @Error 1 @Extended 2 Return 0 = $oDocInfoPrintDtTmField not an Object.
+;                  @Error 1 @Extended 2 Return 0 = $oDocInfoPrintDtTm not an Object.
 ;                  @Error 1 @Extended 3 Return 0 = $bIsFixed not a Boolean.
 ;                  @Error 1 @Extended 4 Return 0 = $iDateFormatKey not an Integer.
 ;                  @Error 1 @Extended 5 Return 0 = $iDateFormatKey not found in document.
@@ -2213,7 +2213,7 @@ EndFunc   ;==>_LOWriter_FieldDocInfoPrintDateTimeInsert
 ; Link ..........:
 ; Example .......: Yes
 ; ===============================================================================================================================
-Func _LOWriter_FieldDocInfoPrintDateTimeModify(ByRef $oDoc, ByRef $oDocInfoPrintDtTmField, $bIsFixed = Null, $iDateFormatKey = Null)
+Func _LOWriter_FieldDocInfoPrintDateTimeModify(ByRef $oDoc, ByRef $oDocInfoPrintDtTm, $bIsFixed = Null, $iDateFormatKey = Null)
 	Local $oCOM_ErrorHandler = ObjEvent("AutoIt.Error", __LOWriter_InternalComErrorHandler)
 	#forceref $oCOM_ErrorHandler
 
@@ -2221,33 +2221,33 @@ Func _LOWriter_FieldDocInfoPrintDateTimeModify(ByRef $oDoc, ByRef $oDocInfoPrint
 	Local $avDocInfoPrntDate[2]
 
 	If Not IsObj($oDoc) Then Return SetError($__LO_STATUS_INPUT_ERROR, 1, 0)
-	If Not IsObj($oDocInfoPrintDtTmField) Then Return SetError($__LO_STATUS_INPUT_ERROR, 2, 0)
+	If Not IsObj($oDocInfoPrintDtTm) Then Return SetError($__LO_STATUS_INPUT_ERROR, 2, 0)
 
 	If __LOWriter_VarsAreNull($bIsFixed, $iDateFormatKey) Then
 		; Libre Office Seems to insert its Number formats by adding 10,000 to the number, but if I insert that same value, it
 		; fails/causes the wrong format to be used, so, If the Number format is greater than or equal to 10,000, Minus 10,000
 		; from the value.
-		$iNumberFormat = $oDocInfoPrintDtTmField.NumberFormat()
+		$iNumberFormat = $oDocInfoPrintDtTm.NumberFormat()
 		$iNumberFormat = ($iNumberFormat >= 10000) ? ($iNumberFormat - 10000) : ($iNumberFormat)
 
-		__LOWriter_ArrayFill($avDocInfoPrntDate, $oDocInfoPrintDtTmField.IsFixed(), $iNumberFormat)
+		__LOWriter_ArrayFill($avDocInfoPrntDate, $oDocInfoPrintDtTm.IsFixed(), $iNumberFormat)
 		Return SetError($__LO_STATUS_SUCCESS, 1, $avDocInfoPrntDate)
 	EndIf
 
 	If ($bIsFixed <> Null) Then
 		If Not IsBool($bIsFixed) Then Return SetError($__LO_STATUS_INPUT_ERROR, 3, 0)
-		$oDocInfoPrintDtTmField.IsFixed = $bIsFixed
-		$iError = ($oDocInfoPrintDtTmField.IsFixed() = $bIsFixed) ? ($iError) : (BitOR($iError, 1))
+		$oDocInfoPrintDtTm.IsFixed = $bIsFixed
+		$iError = ($oDocInfoPrintDtTm.IsFixed() = $bIsFixed) ? ($iError) : (BitOR($iError, 1))
 	EndIf
 
 	If ($iDateFormatKey <> Null) Then
 		If Not IsInt($iDateFormatKey) Then Return SetError($__LO_STATUS_INPUT_ERROR, 4, 0)
 		If Not _LOWriter_DateFormatKeyExists($oDoc, $iDateFormatKey) Then Return SetError($__LO_STATUS_INPUT_ERROR, 5, 0)
-		$oDocInfoPrintDtTmField.NumberFormat = $iDateFormatKey
-		$iError = ($oDocInfoPrintDtTmField.NumberFormat() = $iDateFormatKey) ? ($iError) : (BitOR($iError, 2))
+		$oDocInfoPrintDtTm.NumberFormat = $iDateFormatKey
+		$iError = ($oDocInfoPrintDtTm.NumberFormat() = $iDateFormatKey) ? ($iError) : (BitOR($iError, 2))
 	EndIf
 
-	If ($oDocInfoPrintDtTmField.IsFixed() = False) Then $oDocInfoPrintDtTmField.Update()
+	If ($oDocInfoPrintDtTm.IsFixed() = False) Then $oDocInfoPrintDtTm.Update()
 
 	Return ($iError > 0) ? (SetError($__LO_STATUS_PROP_SETTING_ERROR, $iError, 0)) : (SetError($__LO_STATUS_SUCCESS, 0, 1))
 EndFunc   ;==>_LOWriter_FieldDocInfoPrintDateTimeModify
@@ -2319,14 +2319,14 @@ EndFunc   ;==>_LOWriter_FieldDocInfoRevNumInsert
 ; #FUNCTION# ====================================================================================================================
 ; Name ..........: _LOWriter_FieldDocInfoRevNumModify
 ; Description ...: Set or Retrieve a Document Information Revision Number Field's settings.
-; Syntax ........: _LOWriter_FieldDocInfoRevNumModify(ByRef $oDocInfoRevNumField[, $bIsFixed = Null[, $iRevNum = Null]])
-; Parameters ....: $oDocInfoRevNumField - [in/out] an object. A Doc Info Revision Number field Object from a previous _LOWriter_FieldDocInfoRevNumInsert, or _LOWriter_FieldsDocInfoGetList function.
+; Syntax ........: _LOWriter_FieldDocInfoRevNumModify(ByRef $oDocInfoRevNum[, $bIsFixed = Null[, $iRevNum = Null]])
+; Parameters ....: $oDocInfoRevNum      - [in/out] an object. A Doc Info Revision Number field Object from a previous _LOWriter_FieldDocInfoRevNumInsert, or _LOWriter_FieldsDocInfoGetList function.
 ;                  $bIsFixed            - [optional] a boolean value. Default is Null. If True, the value is static, that is, the value does not update if the source changes or all fields are updated.
 ;                  $iRevNum             - [optional] a Integer value. Default is Null. The Revision Number Integer to display, note, $bIsFixed must be True for this to be displayed.
 ; Return values .: Success: 1 or Array.
 ;                  Failure: 0 and sets the @Error and @Extended flags to non-zero.
 ;                  --Input Errors--
-;                  @Error 1 @Extended 1 Return 0 = $oDocInfoRevNumField not an Object.
+;                  @Error 1 @Extended 1 Return 0 = $oDocInfoRevNum not an Object.
 ;                  @Error 1 @Extended 2 Return 0 = $bIsFixed not a Boolean.
 ;                  @Error 1 @Extended 3 Return 0 = $iRevNum not an Integer.
 ;                  --Property Setting Errors--
@@ -2344,33 +2344,33 @@ EndFunc   ;==>_LOWriter_FieldDocInfoRevNumInsert
 ; Link ..........:
 ; Example .......: Yes
 ; ===============================================================================================================================
-Func _LOWriter_FieldDocInfoRevNumModify(ByRef $oDocInfoRevNumField, $bIsFixed = Null, $iRevNum = Null)
+Func _LOWriter_FieldDocInfoRevNumModify(ByRef $oDocInfoRevNum, $bIsFixed = Null, $iRevNum = Null)
 	Local $oCOM_ErrorHandler = ObjEvent("AutoIt.Error", __LOWriter_InternalComErrorHandler)
 	#forceref $oCOM_ErrorHandler
 
 	Local $iError = 0
 	Local $avDocInfoRev[2]
 
-	If Not IsObj($oDocInfoRevNumField) Then Return SetError($__LO_STATUS_INPUT_ERROR, 1, 0)
+	If Not IsObj($oDocInfoRevNum) Then Return SetError($__LO_STATUS_INPUT_ERROR, 1, 0)
 
 	If __LOWriter_VarsAreNull($bIsFixed, $iRevNum) Then
-		__LOWriter_ArrayFill($avDocInfoRev, $oDocInfoRevNumField.IsFixed(), $oDocInfoRevNumField.Revision())
+		__LOWriter_ArrayFill($avDocInfoRev, $oDocInfoRevNum.IsFixed(), $oDocInfoRevNum.Revision())
 		Return SetError($__LO_STATUS_SUCCESS, 1, $avDocInfoRev)
 	EndIf
 
 	If ($bIsFixed <> Null) Then
 		If Not IsBool($bIsFixed) Then Return SetError($__LO_STATUS_INPUT_ERROR, 2, 0)
-		$oDocInfoRevNumField.IsFixed = $bIsFixed
-		$iError = ($oDocInfoRevNumField.IsFixed() = $bIsFixed) ? ($iError) : (BitOR($iError, 1))
+		$oDocInfoRevNum.IsFixed = $bIsFixed
+		$iError = ($oDocInfoRevNum.IsFixed() = $bIsFixed) ? ($iError) : (BitOR($iError, 1))
 	EndIf
 
 	If ($iRevNum <> Null) Then
 		If Not IsInt($iRevNum) Then Return SetError($__LO_STATUS_INPUT_ERROR, 3, 0)
-		$oDocInfoRevNumField.Revision = $iRevNum
-		$iError = ($oDocInfoRevNumField.Revision() = $iRevNum) ? ($iError) : (BitOR($iError, 2))
+		$oDocInfoRevNum.Revision = $iRevNum
+		$iError = ($oDocInfoRevNum.Revision() = $iRevNum) ? ($iError) : (BitOR($iError, 2))
 	EndIf
 
-	If ($oDocInfoRevNumField.IsFixed() = False) Then $oDocInfoRevNumField.Update()
+	If ($oDocInfoRevNum.IsFixed() = False) Then $oDocInfoRevNum.Update()
 
 	Return ($iError > 0) ? (SetError($__LO_STATUS_PROP_SETTING_ERROR, $iError, 0)) : (SetError($__LO_STATUS_SUCCESS, 0, 1))
 EndFunc   ;==>_LOWriter_FieldDocInfoRevNumModify
@@ -2442,14 +2442,14 @@ EndFunc   ;==>_LOWriter_FieldDocInfoSubjectInsert
 ; #FUNCTION# ====================================================================================================================
 ; Name ..........: _LOWriter_FieldDocInfoSubjectModify
 ; Description ...: Set or Retrieve a Document Information Subject Field's settings.
-; Syntax ........: _LOWriter_FieldDocInfoSubjectModify(ByRef $oDocInfoSubField[, $bIsFixed = Null[, $sSubject = Null]])
-; Parameters ....: $oDocInfoSubField    - [in/out] an object. A Doc Info Subject field Object from a previous _LOWriter_FieldDocInfoSubjectInsert, or _LOWriter_FieldsDocInfoGetList function.
+; Syntax ........: _LOWriter_FieldDocInfoSubjectModify(ByRef $oDocInfoSub[, $bIsFixed = Null[, $sSubject = Null]])
+; Parameters ....: $oDocInfoSub         - [in/out] an object. A Doc Info Subject field Object from a previous _LOWriter_FieldDocInfoSubjectInsert, or _LOWriter_FieldsDocInfoGetList function.
 ;                  $bIsFixed            - [optional] a boolean value. Default is Null. If True, the value is static, that is, the value does not update if the source changes or all fields are updated.
 ;                  $sSubject            - [optional] a string value. Default is Null. The Subject text to display, note, $bIsFixed must be True for this to be displayed.
 ; Return values .: Success: 1 or Array.
 ;                  Failure: 0 and sets the @Error and @Extended flags to non-zero.
 ;                  --Input Errors--
-;                  @Error 1 @Extended 1 Return 0 = $oDocInfoSubField not an Object.
+;                  @Error 1 @Extended 1 Return 0 = $oDocInfoSub not an Object.
 ;                  @Error 1 @Extended 2 Return 0 = $bIsFixed not a Boolean.
 ;                  @Error 1 @Extended 3 Return 0 = $sSubject not a String.
 ;                  --Property Setting Errors--
@@ -2467,33 +2467,33 @@ EndFunc   ;==>_LOWriter_FieldDocInfoSubjectInsert
 ; Link ..........:
 ; Example .......: Yes
 ; ===============================================================================================================================
-Func _LOWriter_FieldDocInfoSubjectModify(ByRef $oDocInfoSubField, $bIsFixed = Null, $sSubject = Null)
+Func _LOWriter_FieldDocInfoSubjectModify(ByRef $oDocInfoSub, $bIsFixed = Null, $sSubject = Null)
 	Local $oCOM_ErrorHandler = ObjEvent("AutoIt.Error", __LOWriter_InternalComErrorHandler)
 	#forceref $oCOM_ErrorHandler
 
 	Local $iError = 0
 	Local $avDocInfoSub[2]
 
-	If Not IsObj($oDocInfoSubField) Then Return SetError($__LO_STATUS_INPUT_ERROR, 1, 0)
+	If Not IsObj($oDocInfoSub) Then Return SetError($__LO_STATUS_INPUT_ERROR, 1, 0)
 
 	If __LOWriter_VarsAreNull($bIsFixed, $sSubject) Then
-		__LOWriter_ArrayFill($avDocInfoSub, $oDocInfoSubField.IsFixed(), $oDocInfoSubField.Content())
+		__LOWriter_ArrayFill($avDocInfoSub, $oDocInfoSub.IsFixed(), $oDocInfoSub.Content())
 		Return SetError($__LO_STATUS_SUCCESS, 1, $avDocInfoSub)
 	EndIf
 
 	If ($bIsFixed <> Null) Then
 		If Not IsBool($bIsFixed) Then Return SetError($__LO_STATUS_INPUT_ERROR, 2, 0)
-		$oDocInfoSubField.IsFixed = $bIsFixed
-		$iError = ($oDocInfoSubField.IsFixed() = $bIsFixed) ? ($iError) : (BitOR($iError, 1))
+		$oDocInfoSub.IsFixed = $bIsFixed
+		$iError = ($oDocInfoSub.IsFixed() = $bIsFixed) ? ($iError) : (BitOR($iError, 1))
 	EndIf
 
 	If ($sSubject <> Null) Then
 		If Not IsString($sSubject) Then Return SetError($__LO_STATUS_INPUT_ERROR, 3, 0)
-		$oDocInfoSubField.Content = $sSubject
-		$iError = ($oDocInfoSubField.Content() = $sSubject) ? ($iError) : (BitOR($iError, 2))
+		$oDocInfoSub.Content = $sSubject
+		$iError = ($oDocInfoSub.Content() = $sSubject) ? ($iError) : (BitOR($iError, 2))
 	EndIf
 
-	If ($oDocInfoSubField.IsFixed() = False) Then $oDocInfoSubField.Update()
+	If ($oDocInfoSub.IsFixed() = False) Then $oDocInfoSub.Update()
 
 	Return ($iError > 0) ? (SetError($__LO_STATUS_PROP_SETTING_ERROR, $iError, 0)) : (SetError($__LO_STATUS_SUCCESS, 0, 1))
 EndFunc   ;==>_LOWriter_FieldDocInfoSubjectModify
@@ -2565,14 +2565,14 @@ EndFunc   ;==>_LOWriter_FieldDocInfoTitleInsert
 ; #FUNCTION# ====================================================================================================================
 ; Name ..........: _LOWriter_FieldDocInfoTitleModify
 ; Description ...: Set or Retrieve a Document Information Title Field's settings.
-; Syntax ........: _LOWriter_FieldDocInfoTitleModify(ByRef $oDocInfoTitleField[, $bIsFixed = Null[, $sTitle = Null]])
-; Parameters ....: $oDocInfoTitleField  - [in/out] an object. A Doc Info Title field Object from a previous _LOWriter_FieldDocInfoTitleInsert, or _LOWriter_FieldsDocInfoGetList function.
+; Syntax ........: _LOWriter_FieldDocInfoTitleModify(ByRef $oDocInfoTitle[, $bIsFixed = Null[, $sTitle = Null]])
+; Parameters ....: $oDocInfoTitle       - [in/out] an object. A Doc Info Title field Object from a previous _LOWriter_FieldDocInfoTitleInsert, or _LOWriter_FieldsDocInfoGetList function.
 ;                  $bIsFixed            - [optional] a boolean value. Default is Null. If True, the value is static, that is, the value does not update if the source changes or all fields are updated.
 ;                  $sTitle              - [optional] a string value. Default is Null. The Title text to display, note, $bIsFixed must be True for this to be displayed.
 ; Return values .: Success: 1 or Array.
 ;                  Failure: 0 and sets the @Error and @Extended flags to non-zero.
 ;                  --Input Errors--
-;                  @Error 1 @Extended 1 Return 0 = $oDocInfoTitleField not an Object.
+;                  @Error 1 @Extended 1 Return 0 = $oDocInfoTitle not an Object.
 ;                  @Error 1 @Extended 2 Return 0 = $bIsFixed not a Boolean.
 ;                  @Error 1 @Extended 3 Return 0 = $sTitle not a String.
 ;                  --Property Setting Errors--
@@ -2590,33 +2590,33 @@ EndFunc   ;==>_LOWriter_FieldDocInfoTitleInsert
 ; Link ..........:
 ; Example .......: Yes
 ; ===============================================================================================================================
-Func _LOWriter_FieldDocInfoTitleModify(ByRef $oDocInfoTitleField, $bIsFixed = Null, $sTitle = Null)
+Func _LOWriter_FieldDocInfoTitleModify(ByRef $oDocInfoTitle, $bIsFixed = Null, $sTitle = Null)
 	Local $oCOM_ErrorHandler = ObjEvent("AutoIt.Error", __LOWriter_InternalComErrorHandler)
 	#forceref $oCOM_ErrorHandler
 
 	Local $iError = 0
 	Local $avDocInfoTitle[2]
 
-	If Not IsObj($oDocInfoTitleField) Then Return SetError($__LO_STATUS_INPUT_ERROR, 1, 0)
+	If Not IsObj($oDocInfoTitle) Then Return SetError($__LO_STATUS_INPUT_ERROR, 1, 0)
 
 	If __LOWriter_VarsAreNull($bIsFixed, $sTitle) Then
-		__LOWriter_ArrayFill($avDocInfoTitle, $oDocInfoTitleField.IsFixed(), $oDocInfoTitleField.Content())
+		__LOWriter_ArrayFill($avDocInfoTitle, $oDocInfoTitle.IsFixed(), $oDocInfoTitle.Content())
 		Return SetError($__LO_STATUS_SUCCESS, 1, $avDocInfoTitle)
 	EndIf
 
 	If ($bIsFixed <> Null) Then
 		If Not IsBool($bIsFixed) Then Return SetError($__LO_STATUS_INPUT_ERROR, 2, 0)
-		$oDocInfoTitleField.IsFixed = $bIsFixed
-		$iError = ($oDocInfoTitleField.IsFixed() = $bIsFixed) ? ($iError) : (BitOR($iError, 1))
+		$oDocInfoTitle.IsFixed = $bIsFixed
+		$iError = ($oDocInfoTitle.IsFixed() = $bIsFixed) ? ($iError) : (BitOR($iError, 1))
 	EndIf
 
 	If ($sTitle <> Null) Then
 		If Not IsString($sTitle) Then Return SetError($__LO_STATUS_INPUT_ERROR, 3, 0)
-		$oDocInfoTitleField.Content = $sTitle
-		$iError = ($oDocInfoTitleField.Content() = $sTitle) ? ($iError) : (BitOR($iError, 2))
+		$oDocInfoTitle.Content = $sTitle
+		$iError = ($oDocInfoTitle.Content() = $sTitle) ? ($iError) : (BitOR($iError, 2))
 	EndIf
 
-	If ($oDocInfoTitleField.IsFixed() = False) Then $oDocInfoTitleField.Update()
+	If ($oDocInfoTitle.IsFixed() = False) Then $oDocInfoTitle.Update()
 
 	Return ($iError > 0) ? (SetError($__LO_STATUS_PROP_SETTING_ERROR, $iError, 0)) : (SetError($__LO_STATUS_SUCCESS, 0, 1))
 EndFunc   ;==>_LOWriter_FieldDocInfoTitleModify
@@ -5728,8 +5728,8 @@ EndFunc   ;==>_LOWriter_FieldVarShowPageInsert
 ; Name ..........: _LOWriter_FieldVarShowPageModify
 ; Description ...: Set or Retrieve a Show Page Variable Field's settings.
 ; Syntax ........: _LOWriter_FieldVarShowPageModify(ByRef $oPageShowField[, $iNumFormat = Null])
-; Parameters ....: $oPageShowField        - [in/out] an object. A Show Page Variable field Object from a previous _LOWriter_FieldVarShowPageInsert, or _LOWriter_FieldsGetList function.
-;                  $iNumFormat            - [optional] an integer value (0-71). Default is Null. The numbering format to use for Show Page Variable numbering. See Constants, $LOW_NUM_STYLE_* as defined in LibreOfficeWriter_Constants.au3.
+; Parameters ....: $oPageShowField      - [in/out] an object. A Show Page Variable field Object from a previous _LOWriter_FieldVarShowPageInsert, or _LOWriter_FieldsGetList function.
+;                  $iNumFormat          - [optional] an integer value (0-71). Default is Null. The numbering format to use for Show Page Variable numbering. See Constants, $LOW_NUM_STYLE_* as defined in LibreOfficeWriter_Constants.au3.
 ; Return values .: Success: 1 or Integer.
 ;                  Failure: 0 and sets the @Error and @Extended flags to non-zero.
 ;                  --Input Errors--

--- a/LibreOfficeWriter_Font.au3
+++ b/LibreOfficeWriter_Font.au3
@@ -68,7 +68,7 @@ EndFunc   ;==>_LOWriter_FontExists
 ; Name ..........: _LOWriter_FontsList
 ; Description ...: Retrieve a list of currently available fonts.
 ; Syntax ........: _LOWriter_FontsList(ByRef $oDoc)
-; Parameters ....: $oDoc           - [in/out] an object. A Document object returned by a previous _LOWriter_DocOpen, _LOWriter_DocConnect, or _LOWriter_DocCreate function.
+; Parameters ....: $oDoc                - [in/out] an object. A Document object returned by a previous _LOWriter_DocOpen, _LOWriter_DocConnect, or _LOWriter_DocCreate function.
 ; Return values .: Success: Array
 ;                  Failure: 0 and sets the @Error and @Extended flags to non-zero.
 ;                  --Input Errors--

--- a/LibreOfficeWriter_Frame.au3
+++ b/LibreOfficeWriter_Frame.au3
@@ -1443,7 +1443,7 @@ EndFunc   ;==>_LOWriter_FrameOptionsName
 ; Name ..........: _LOWriter_FramesGetNames
 ; Description ...: List the names of all frames contained in a document.
 ; Syntax ........: _LOWriter_FramesGetNames(ByRef $oDoc[, $bSearchShapes = False])
-; Parameters ....: $oDoc           - [in/out] an object. A Document object returned by a previous _LOWriter_DocOpen, _LOWriter_DocConnect, or _LOWriter_DocCreate function.
+; Parameters ....: $oDoc                - [in/out] an object. A Document object returned by a previous _LOWriter_DocOpen, _LOWriter_DocConnect, or _LOWriter_DocCreate function.
 ;                  $bSearchShapes       - [optional] a boolean value. Default is False. If True, function searches and adds any Frames listed as "Shapes" in the document to the array of Frame names. See remarks.
 ; Return values .: Success: Array of Strings.
 ;                  Failure: 0 and sets the @Error and @Extended flags to non-zero.
@@ -2465,8 +2465,8 @@ EndFunc   ;==>_LOWriter_FrameStyleColumnSize
 ; Name ..........: _LOWriter_FrameStyleCreate
 ; Description ...: Create a new Frame Style in a Document.
 ; Syntax ........: _LOWriter_FrameStyleCreate(ByRef $oDoc, $sFrameStyle)
-; Parameters ....: $oDoc                  - [in/out] an object. A Document object returned by a previous _LOWriter_DocOpen, _LOWriter_DocConnect, or _LOWriter_DocCreate function.
-;                  $sFrameStyle           - a string value. The Name of the New Frame Style to Create.
+; Parameters ....: $oDoc                - [in/out] an object. A Document object returned by a previous _LOWriter_DocOpen, _LOWriter_DocConnect, or _LOWriter_DocCreate function.
+;                  $sFrameStyle         - a string value. The Name of the New Frame Style to Create.
 ; Return values .: Success: Object
 ;                  Failure: 0 and sets the @Error and @Extended flags to non-zero.
 ;                  --Input Errors--
@@ -2578,7 +2578,7 @@ EndFunc   ;==>_LOWriter_FrameStyleDelete
 ; Description ...: Check whether a Document contains a specific Frame Style by name.
 ; Syntax ........: _LOWriter_FrameStyleExists(ByRef $oDoc, $sFrameStyle)
 ; Parameters ....: $oDoc                - [in/out] an object. A Document object returned by a previous _LOWriter_DocOpen, _LOWriter_DocConnect, or _LOWriter_DocCreate function.
-;                  $sFrameStyle           - a string value. The Frame Style Name to search for.
+;                  $sFrameStyle         - a string value. The Frame Style Name to search for.
 ; Return values .: Success: Boolean
 ;                  Failure: 0 and sets the @Error and @Extended flags to non-zero.
 ;                  --Input Errors--
@@ -2608,8 +2608,8 @@ EndFunc   ;==>_LOWriter_FrameStyleExists
 ; Name ..........: _LOWriter_FrameStyleGetObj
 ; Description ...: Retrieve a Frame Style Object for use with other Frame Style functions.
 ; Syntax ........: _LOWriter_FrameStyleGetObj(ByRef $oDoc, $sFrameStyle)
-; Parameters ....: $oDoc                  - [in/out] an object. A Document object returned by a previous _LOWriter_DocOpen, _LOWriter_DocConnect, or _LOWriter_DocCreate function.
-;                  $sFrameStyle           - a string value. The Frame Style name to retrieve the Object for.
+; Parameters ....: $oDoc                - [in/out] an object. A Document object returned by a previous _LOWriter_DocOpen, _LOWriter_DocConnect, or _LOWriter_DocCreate function.
+;                  $sFrameStyle         - a string value. The Frame Style name to retrieve the Object for.
 ; Return values .: Success: Object
 ;                  Failure: 0 and sets the @Error and @Extended flags to non-zero.
 ;                  --Input Errors--
@@ -2847,9 +2847,9 @@ EndFunc   ;==>_LOWriter_FrameStyleOrganizer
 ; Name ..........: _LOWriter_FrameStyleSet
 ; Description ...: Set a Frame to a certain Frame style.
 ; Syntax ........: _LOWriter_FrameStyleSet(ByRef $oDoc, ByRef $oFrameObj, $sFrameStyle)
-; Parameters ....: $oDoc                 - [in/out] an object. A Document object returned by a previous _LOWriter_DocOpen, _LOWriter_DocConnect, or _LOWriter_DocCreate function.
-;                  $oFrameObj            - [in/out] an object. A Frame object returned by a previous _LOWriter_FrameCreate, _LOWriter_FrameGetObjByName, or _LOWriter_FrameGetObjByCursor function.
-;                  $sFrameStyle          - a string value. The Frame Style name to set the frame to.
+; Parameters ....: $oDoc                - [in/out] an object. A Document object returned by a previous _LOWriter_DocOpen, _LOWriter_DocConnect, or _LOWriter_DocCreate function.
+;                  $oFrameObj           - [in/out] an object. A Frame object returned by a previous _LOWriter_FrameCreate, _LOWriter_FrameGetObjByName, or _LOWriter_FrameGetObjByCursor function.
+;                  $sFrameStyle         - a string value. The Frame Style name to set the frame to.
 ; Return values .: Success: 1
 ;                  Failure: 0 and sets the @Error and @Extended flags to non-zero.
 ;                  --Input Errors--

--- a/LibreOfficeWriter_Helper.au3
+++ b/LibreOfficeWriter_Helper.au3
@@ -2452,7 +2452,7 @@ EndFunc   ;==>_LOWriter_FormatKeyList
 ;                  @Error 0 @Extended 2 Return String = Returning converted path from File Path to Libre Office URL.
 ; Author ........: donnyh13
 ; Modified ......:
-; Remarks .......: LibeOffice URL notation is based on the Internet Standard RFC 1738, which means only [0-9],[a-zA-Z] are allowed in paths, most other characters need to be converted into ISO 8859-1 (ISO Latin) such as is found in internet URL's (spaces become %20).
+; Remarks .......: LibreOffice URL notation is based on the Internet Standard RFC 1738, which means only [0-9],[a-zA-Z] are allowed in paths, most other characters need to be converted into ISO 8859-1 (ISO Latin) such as is found in internet URL's (spaces become %20).
 ;                  See: StarOfficeTM 6.0 Office SuiteA SunTM ONE Software Offering, Basic Programmer's Guide; Page 74
 ;                  The user generally should not even need this function, as I have endeavored to convert any URLs to the appropriate computer path format and any input computer paths to a Libre Office URL.
 ; Related .......:

--- a/LibreOfficeWriter_Images.au3
+++ b/LibreOfficeWriter_Images.au3
@@ -1348,7 +1348,7 @@ EndFunc   ;==>_LOWriter_ImageModify
 ; Name ..........: _LOWriter_ImageOptions
 ; Description ...: Set or Retrieve Image Options.
 ; Syntax ........: _LOWriter_ImageOptions(ByRef $oImage[, $bProtectContent = Null[, $bProtectPos = Null[, $bProtectSize = Null[, $bPrint = Null]]]])
-; Parameters ....: $oImage           - [in/out] an object. A Image object returned by a previous _LOWriter_ImageInsert, or _LOWriter_ImageGetObjByName function.
+; Parameters ....: $oImage              - [in/out] an object. A Image object returned by a previous _LOWriter_ImageInsert, or _LOWriter_ImageGetObjByName function.
 ;                  $bProtectContent     - [optional] a boolean value. Default is Null. If True, Prevents changes to the contents of the Image.
 ;                  $bProtectPos         - [optional] a boolean value. Default is Null. If True, Locks the position of the Image in the current document.
 ;                  $bProtectSize        - [optional] a boolean value. Default is Null. If True, Locks the size of the Image.
@@ -2173,7 +2173,7 @@ EndFunc   ;==>_LOWriter_ImageTypeSize
 ; Name ..........: _LOWriter_ImageWrap
 ; Description ...: Set or Retrieve Image Wrap and Spacing settings.
 ; Syntax ........: _LOWriter_ImageWrap(ByRef $oImage[, $iWrapType = Null[, $iLeft = Null[, $iRight = Null[, $iTop = Null[, $iBottom = Null]]]]])
-; Parameters ....: $oImage           - [in/out] an object. A Image object returned by a previous _LOWriter_ImageInsert, or _LOWriter_ImageGetObjByName function.
+; Parameters ....: $oImage              - [in/out] an object. A Image object returned by a previous _LOWriter_ImageInsert, or _LOWriter_ImageGetObjByName function.
 ;                  $iWrapType           - [optional] an integer value (0-5). Default is Null. The way to wrap text around the Image. See Constants, $LOW_WRAP_MODE_* as defined in LibreOfficeWriter_Constants.au3.
 ;                  $iLeft               - [optional] an integer value. Default is Null. The amount of space between the left edge of the Image and the text. Set in Micrometers.
 ;                  $iRight              - [optional] an integer value. Default is Null. The amount of space between the Right edge of the Image and the text. Set in Micrometers.

--- a/LibreOfficeWriter_Internal.au3
+++ b/LibreOfficeWriter_Internal.au3
@@ -1471,7 +1471,7 @@ EndFunc   ;==>__LOWriter_CreatePoint
 ; Name ..........: __LOWriter_CreateStruct
 ; Description ...: Retrieves a Struct.
 ; Syntax ........: __LOWriter_CreateStruct($sStructName)
-; Parameters ....: $sStructName - a string value. Name of structure to create.
+; Parameters ....: $sStructName         - a string value. Name of structure to create.
 ; Return values .: Success: Structure.
 ;                  Failure: 0 and sets the @Error and @Extended flags to non-zero.
 ;                  --Input Errors--
@@ -1507,8 +1507,8 @@ EndFunc   ;==>__LOWriter_CreateStruct
 ; Name ..........: __LOWriter_CursorGetText
 ; Description ...: Retrieves a Text object appropriate for the type of cursor.
 ; Syntax ........: __LOWriter_CursorGetText(ByRef $oDoc, $oCursor)
-; Parameters ....: $oDoc        - [in/out] A Document object returned by a previous _LOWriter_DocOpen, _LOWriter_DocConnect, or _LOWriter_DocCreate function.
-;                  $oCursor     - [in/out] an object. A Text or View Cursor Object returned from any Cursor Object creation or retrieval functions.
+; Parameters ....: $oDoc                - [in/out] A Document object returned by a previous _LOWriter_DocOpen, _LOWriter_DocConnect, or _LOWriter_DocCreate function.
+;                  $oCursor             - [in/out] an object. A Text or View Cursor Object returned from any Cursor Object creation or retrieval functions.
 ; Return values .: Success: Object.
 ;                  Failure: 0 and sets the @Error and @Extended flags to non-zero.
 ;                  --Input Errors--
@@ -1867,14 +1867,14 @@ EndFunc   ;==>__LOWriter_FieldTypeServices
 ; #INTERNAL_USE_ONLY# ===========================================================================================================
 ; Name ..........: __LOWriter_FilterNameGet
 ; Description ...: Retrieves the correct L.O. Filtername for use in SaveAs and Export.
-; Syntax ........: __LOWriter_FilterNameGet(ByRef $sDocSavePath[, $bIncludeExportFilters = False])
-; Parameters ....: $sDocSavePath           - [in/out] a string value. Full path with extension.
-;                  $bIncludeExportFilters  - [optional] a boolean value. Default is False. If True, includes the FilterNames that can be used to Export only, in the search.
+; Syntax ........: __LOWriter_FilterNameGet(ByRef $sDocSavePath[, $bExportFilters = False])
+; Parameters ....: $sDocSavePath        - [in/out] a string value. Full path with extension.
+;                  $bExportFilters      - [optional] a boolean value. Default is False. If True, includes the FilterNames that can be used to Export only, in the search.
 ; Return values .: Success: String.
 ;                  Failure: 0 and sets the @Error and @Extended flags to non-zero.
 ;                  --Input Errors--
 ;                  @Error 1 @Extended 1 Return 0 = $sDocSavePath is not a string.
-;                  @Error 1 @Extended 2 Return 0 = $bIncludeExportFilters not a Boolean.
+;                  @Error 1 @Extended 2 Return 0 = $bExportFilters not a Boolean.
 ;                  @Error 1 @Extended 3 Return 0 = $sDocSavePath is not a correct path or URL.
 ;                  --Success--
 ;                  @Error 0 @Extended 1 Return String = Success. Returns required filtername from "SaveAs" FilterNames.
@@ -1889,14 +1889,14 @@ EndFunc   ;==>__LOWriter_FieldTypeServices
 ; Link ..........:
 ; Example .......: No
 ; ===============================================================================================================================
-Func __LOWriter_FilterNameGet(ByRef $sDocSavePath, $bIncludeExportFilters = False)
+Func __LOWriter_FilterNameGet(ByRef $sDocSavePath, $bExportFilters = False)
 	Local $iLength, $iSlashLocation, $iDotLocation
 	Local Const $STR_NOCASESENSE = 0, $STR_STRIPALL = 8
 	Local $sFileExtension, $sFilterName
 	Local $msSaveAsFilters[], $msExportFilters[]
 
 	If Not IsString($sDocSavePath) Then Return SetError($__LO_STATUS_INPUT_ERROR, 1, 0)
-	If Not IsBool($bIncludeExportFilters) Then Return SetError($__LO_STATUS_INPUT_ERROR, 2, 0)
+	If Not IsBool($bExportFilters) Then Return SetError($__LO_STATUS_INPUT_ERROR, 2, 0)
 	$iLength = StringLen($sDocSavePath)
 
 	$msSaveAsFilters[".doc"] = "MS Word 97"
@@ -1913,7 +1913,7 @@ Func __LOWriter_FilterNameGet(ByRef $sDocSavePath, $bIncludeExportFilters = Fals
 	$msSaveAsFilters[".uot"] = "UOF text"
 	$msSaveAsFilters[".xml"] = "MS Word 2003 XML"
 
-	If $bIncludeExportFilters Then
+	If $bExportFilters Then
 		$msExportFilters[".epub"] = "EPUB"
 		$msExportFilters[".jfif"] = "writer_jpg_Export"
 		$msExportFilters[".jif"] = "writer_jpg_Export"
@@ -1948,7 +1948,7 @@ Func __LOWriter_FilterNameGet(ByRef $sDocSavePath, $bIncludeExportFilters = Fals
 
 	If IsString($sFilterName) Then Return SetError($__LO_STATUS_SUCCESS, 1, $sFilterName)
 
-	If $bIncludeExportFilters Then $sFilterName = $msExportFilters[$sFileExtension]
+	If $bExportFilters Then $sFilterName = $msExportFilters[$sFileExtension]
 
 	If IsString($sFilterName) Then Return SetError($__LO_STATUS_SUCCESS, 2, $sFilterName)
 
@@ -2814,9 +2814,9 @@ EndFunc   ;==>__LOWriter_ImageGetSuggestedSize
 ; Name ..........: __LOWriter_Internal_CursorGetDataType
 ; Description ...: Get what type of Text data the cursor object is currently in. Internal version of CursorGetDataType.
 ; Syntax ........: __LOWriter_Internal_CursorGetDataType(ByRef $oDoc, ByRef $oCursor[, $bReturnObject = False])
-; Parameters ....: $oDoc                 - [in/out] an object. A Document object returned by a previous _LOWriter_DocOpen, _LOWriter_DocConnect, or _LOWriter_DocCreate function.
-;                  $oCursor              - [in/out] an object. A Cursor Object returned from any Cursor Object creation or retrieval functions.
-;                  $bReturnObject        - [optional] a boolean value. Default is False. If True, return the object used for creating a Text Object etc.
+; Parameters ....: $oDoc                - [in/out] an object. A Document object returned by a previous _LOWriter_DocOpen, _LOWriter_DocConnect, or _LOWriter_DocCreate function.
+;                  $oCursor             - [in/out] an object. A Cursor Object returned from any Cursor Object creation or retrieval functions.
+;                  $bReturnObject       - [optional] a boolean value. Default is False. If True, return the object used for creating a Text Object etc.
 ; Return values .: Success: Object or Integer.
 ;                  Failure: 0 and sets the @Error and @Extended flags to non-zero.
 ;                  --Input Errors--
@@ -8303,7 +8303,7 @@ EndFunc   ;==>__LOWriter_VarsAreNull
 ; Name ..........: __LOWriter_VersionCheck
 ; Description ...: Test if the currently installed LibreOffice version is high enough to support a certain function.
 ; Syntax ........: __LOWriter_VersionCheck($fRequiredVersion)
-; Parameters ....: $fRequiredVersion            - a floating point value. The version of LibreOffice required.
+; Parameters ....: $fRequiredVersion    - a floating point value. The version of LibreOffice required.
 ; Return values .: Success: Boolean.
 ;                  Failure: 0 and sets the @Error and @Extended flags to non-zero.
 ;                  --Input Errors--

--- a/LibreOfficeWriter_Internal.au3
+++ b/LibreOfficeWriter_Internal.au3
@@ -1733,6 +1733,8 @@ Func __LOWriter_FieldsGetList(ByRef $oDoc, $bSupportedServices, $bFieldType, $bF
 	$iColumns = ($bFieldType = False) ? ($iColumns - 1) : ($iColumns)
 	$iColumns = ($bFieldTypeNum = False) ? ($iColumns - 1) : ($iColumns)
 
+	If ($iColumns = 1) Then ReDim $avTextFields[UBound($avTextFields)]
+
 	; If Supported Services Option is False, change the column position of FieldType
 	$iFieldTypeCol = ($bSupportedServices = False) ? ($iFieldTypeCol - 1) : ($iFieldTypeCol)
 
@@ -1749,22 +1751,36 @@ Func __LOWriter_FieldsGetList(ByRef $oDoc, $bSupportedServices, $bFieldType, $bF
 
 			If $oTextField.supportsService($avFieldTypes[$i][1]) Then
 
-				$avTextFields[$iCount][0] = $oTextField
+				If ($iColumns = 1) Then
+					$avTextFields[$iCount] = $oTextField
 
-				If ($bSupportedServices = True) Then $avTextFields[$iCount][1] = $avFieldTypes[$i][1]
-				If ($bFieldType = True) Then $avTextFields[$iCount][$iFieldTypeCol] = $oTextField.getPresentation(True)
-				If ($bFieldTypeNum = True) Then $avTextFields[$iCount][$iFieldTypeNumCol] = $avFieldTypes[$i][0]
+					$iCount += 1
+					If ($iCount = UBound($avTextFields)) Then ReDim $avTextFields[$iCount * 2]
+					ExitLoop
+				Else
 
-				$iCount += 1
-				If ($iCount = UBound($avTextFields)) Then ReDim $avTextFields[$iCount * 2][$iColumns]
-				ExitLoop
+					$avTextFields[$iCount][0] = $oTextField
+
+					If ($bSupportedServices = True) Then $avTextFields[$iCount][1] = $avFieldTypes[$i][1]
+					If ($bFieldType = True) Then $avTextFields[$iCount][$iFieldTypeCol] = $oTextField.getPresentation(True)
+					If ($bFieldTypeNum = True) Then $avTextFields[$iCount][$iFieldTypeNumCol] = $avFieldTypes[$i][0]
+
+					$iCount += 1
+					If ($iCount = UBound($avTextFields)) Then ReDim $avTextFields[$iCount * 2][$iColumns]
+					ExitLoop
+				EndIf
 			EndIf
 			Sleep((IsInt($i / $__LOWCONST_SLEEP_DIV) ? (10) : (0)))
 		Next
 
 	WEnd
 
-	ReDim $avTextFields[$iCount][$iColumns]
+	If ($iColumns = 1) Then
+		ReDim $avTextFields[$iCount]
+	Else
+		ReDim $avTextFields[$iCount][$iColumns]
+	EndIf
+
 	Return SetError($__LO_STATUS_SUCCESS, $iCount, $avTextFields)
 EndFunc   ;==>__LOWriter_FieldsGetList
 
@@ -2770,7 +2786,7 @@ EndFunc   ;==>__LOWriter_HeaderBorder
 ; Example .......: No
 ; ===============================================================================================================================
 Func __LOWriter_ImageGetSuggestedSize($oGraphic, $oPageStyle)
-	Local $oCOM_ErrorHandler = ObjEvent("AutoIt.Error", "__LOWriter_InternalComErrorHandler")
+	Local $oCOM_ErrorHandler = ObjEvent("AutoIt.Error", __LOWriter_InternalComErrorHandler)
 	#forceref $oCOM_ErrorHandler
 
 	Local $oSize

--- a/LibreOfficeWriter_Page.au3
+++ b/LibreOfficeWriter_Page.au3
@@ -2183,8 +2183,8 @@ EndFunc   ;==>_LOWriter_PageStyleFootnoteLine
 ; Name ..........: _LOWriter_PageStyleGetObj
 ; Description ...: Retrieve a Page Style Object for use with other Page Style functions.
 ; Syntax ........: _LOWriter_PageStyleGetObj(ByRef $oDoc, $sPageStyle)
-; Parameters ....: $oDoc                 - [in/out] an object. A Document object returned by a previous _LOWriter_DocOpen, _LOWriter_DocConnect, or _LOWriter_DocCreate function.
-;                  $sPageStyle           - a string value. The Page Style name to retrieve the Object for.
+; Parameters ....: $oDoc                - [in/out] an object. A Document object returned by a previous _LOWriter_DocOpen, _LOWriter_DocConnect, or _LOWriter_DocCreate function.
+;                  $sPageStyle          - a string value. The Page Style name to retrieve the Object for.
 ; Return values .: Success: Object
 ;                  Failure: 0 and sets the @Error and @Extended flags to non-zero.
 ;                  --Input Errors--

--- a/LibreOfficeWriter_Par.au3
+++ b/LibreOfficeWriter_Par.au3
@@ -311,8 +311,8 @@ EndFunc   ;==>_LOWriter_ParObjSectionsGet
 ; Name ..........: _LOWriter_ParObjSelect
 ; Description ...: Causes a Paragraph Object to be selected by the ViewCursor.
 ; Syntax ........: _LOWriter_ParObjSelect(ByRef $oDoc, ByRef $oObj)
-; Parameters ....: $oDoc             - [in/out] an object. A Document object returned by a previous _LOWriter_DocOpen, _LOWriter_DocConnect, or _LOWriter_DocCreate function.
-;                  $oObj             - [in/out] an object. A Paragraph Object returned from _LOWriter_ParObjCreateList, a Table or Frame Object, or a Text Cursor with data selected, can be used.
+; Parameters ....: $oDoc                - [in/out] an object. A Document object returned by a previous _LOWriter_DocOpen, _LOWriter_DocConnect, or _LOWriter_DocCreate function.
+;                  $oObj                - [in/out] an object. A Paragraph Object returned from _LOWriter_ParObjCreateList, a Table or Frame Object, or a Text Cursor with data selected, can be used.
 ; Return values .: Success: Integer
 ;                  Failure: 0 and sets the @Error and @Extended flags to non-zero.
 ;                  --Input Errors--
@@ -1573,9 +1573,9 @@ EndFunc   ;==>_LOWriter_ParStyleRotateScale
 ; Name ..........: _LOWriter_ParStyleSet
 ; Description ...: Set a Paragraph style for a paragraph by Cursor or paragraph Object.
 ; Syntax ........: _LOWriter_ParStyleSet(ByRef $oDoc, ByRef $oObj, $sParStyle)
-; Parameters ....: $oDoc           - [in/out] an object. A Document object returned by a previous _LOWriter_DocOpen, _LOWriter_DocConnect, or _LOWriter_DocCreate function.
-;                  $oObj           - [in/out] an object. A Cursor Object returned from any Cursor Object creation or retrieval functions, Or A Paragraph Object returned from _LOWriter_ParObjCreateList function.
-;                  $sParStyle      - a string value. The Paragraph Style name to set the paragraph to.
+; Parameters ....: $oDoc                - [in/out] an object. A Document object returned by a previous _LOWriter_DocOpen, _LOWriter_DocConnect, or _LOWriter_DocCreate function.
+;                  $oObj                - [in/out] an object. A Cursor Object returned from any Cursor Object creation or retrieval functions, Or A Paragraph Object returned from _LOWriter_ParObjCreateList function.
+;                  $sParStyle           - a string value. The Paragraph Style name to set the paragraph to.
 ; Return values .: Success: 1
 ;                  Failure: 0 and sets the @Error and @Extended flags to non-zero.
 ;                  --Input Errors--
@@ -1613,9 +1613,9 @@ EndFunc   ;==>_LOWriter_ParStyleSet
 ; Name ..........: _LOWriter_ParStylesGetNames
 ; Description ...: Retrieve a list of all Paragraph Style names available for a document.
 ; Syntax ........: _LOWriter_ParStylesGetNames(ByRef $oDoc[, $bUserOnly = False[, $bAppliedOnly = False]])
-; Parameters ....: $oDoc           - [in/out] an object. A Document object returned by a previous _LOWriter_DocOpen, _LOWriter_DocConnect, or _LOWriter_DocCreate function.
-;                  $bUserOnly      - [optional] a boolean value. Default is False. If True only User-Created Paragraph Styles are returned.
-;                  $bAppliedOnly   - [optional] a boolean value. Default is False. If True only Applied Paragraph Styles are returned.
+; Parameters ....: $oDoc                - [in/out] an object. A Document object returned by a previous _LOWriter_DocOpen, _LOWriter_DocConnect, or _LOWriter_DocCreate function.
+;                  $bUserOnly           - [optional] a boolean value. Default is False. If True only User-Created Paragraph Styles are returned.
+;                  $bAppliedOnly        - [optional] a boolean value. Default is False. If True only Applied Paragraph Styles are returned.
 ; Return values .: Success: Integer or Array
 ;                  Failure: 0 and sets the @Error and @Extended flags to non-zero.
 ;                  --Input Errors--

--- a/LibreOfficeWriter_Table.au3
+++ b/LibreOfficeWriter_Table.au3
@@ -1811,7 +1811,7 @@ EndFunc   ;==>_LOWriter_TableSetData
 ; Name ..........: _LOWriter_TablesGetNames
 ; Description ...: List the names of all tables contained in a document.
 ; Syntax ........: _LOWriter_TablesGetNames(ByRef $oDoc)
-; Parameters ....: $oDoc           - [in/out] an object. A Document object returned by a previous _LOWriter_DocOpen, _LOWriter_DocConnect, or _LOWriter_DocCreate function.
+; Parameters ....: $oDoc                - [in/out] an object. A Document object returned by a previous _LOWriter_DocOpen, _LOWriter_DocConnect, or _LOWriter_DocCreate function.
 ; Return values .: Success: 1 or Array of Strings.
 ;                  Failure: 0 and sets the @Error and @Extended flags to non-zero.
 ;                  --Input Errors--

--- a/LibreOfficeWriter_Table.au3
+++ b/LibreOfficeWriter_Table.au3
@@ -1246,8 +1246,8 @@ Func _LOWriter_TableInsert(ByRef $oDoc, $oCursor, ByRef $oTable, $bHeading = Fal
 
 	If IsObj($oCursor) Then
 		$oText = __LOWriter_CursorGetText($oDoc, $oCursor)
-		If @error Then Return SetError($__LO_STATUS_PROCESSING_ERROR, 1, 0)
 		$iCursorDataType = @extended
+		If @error Then Return SetError($__LO_STATUS_PROCESSING_ERROR, 1, 0)
 
 		Switch $iCursorDataType
 			Case $LOW_CURDATA_FOOTNOTE, $LOW_CURDATA_ENDNOTE
@@ -1419,7 +1419,7 @@ EndFunc   ;==>_LOWriter_TableMargin
 ; ===============================================================================================================================
 Func _LOWriter_TableProperties(ByRef $oTable, $iTableAlign = Null, $bKeepTogether = Null, $sTableName = Null, $bSplit = Null, $bSplitRows = Null, $bRepeatHeading = Null, $iHeaderRows = Null)
 	Local $iError = 0
-	Local $oComError = ObjEvent("AutoIt.Error", "__LOWriter_InternalComErrorHandler")
+	Local $oComError = ObjEvent("AutoIt.Error", __LOWriter_InternalComErrorHandler)
 	Local $avProperties[4]
 
 	If Not IsObj($oTable) Then Return SetError($__LO_STATUS_INPUT_ERROR, 1, 0)


### PR DESCRIPTION
## Pull request

### Proposed changes

Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request.<br>
Please ensure you have read and noticed the checklist below.

### Checklist

Put an `x` in the boxes that apply. If you're unsure about any of them, don't hesitate to ask. We are here to help!<br>
This is simply a reminder of what we are going to look for before merging your code.

- [x] I have read and noticed the [CODE OF CONDUCT](https://github.com/mlipok/Au3LibreOffice/tree/main/Docs/CODE_OF_CONDUCT.md) document
- [x] I have read and noticed the [CONTRIBUTING](https://github.com/mlipok/Au3LibreOffice/tree/main/Docs/CONTRIBUTING.md) document
- [x] I have added necessary documentation or screenshots (if appropriate)
- [x] I have tested my changes or additions for proper functionality.
- [x] I have followed, as best as possible, the same function layout and coding style of other existing functions/code.

### Types of changes

Please check `x` the type of change your PR introduces:

- [x] Bugfix (change which fixes an issue)
- [ ] Feature (change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (functional, structural)
- [x] Documentation content changes
- [ ] Other (please describe) <br>
**	|-->:

### What is the current behavior?

Please describe the current behavior that you are modifying, or link to a relevant issue. <br>
**	|-->:
- Some header Parameters weren't aligned to Column 41
- One of the last Patches broke _LOWriter_DocCreateTextCursor, where it would error when creating a Cursor at the View Cursor.
- When using Writer's Fields get list functions, itn it was supposed to return a 1D array, it still returned 2D array with one column.

### What is the new behavior?

Please describe the behavior or changes that are being added by this PR. <br>
**	|-->:
- Fixed alignment
- Fixed _LOWriter_DocCreateTextCursor by moving the assignment of @extended.
- Changed how the Array is created in the internal function so that a 1D array or 2D can be returned appropriately.

### Influences and relationship to other functionality

Describe how the changes will affect other functions, potential script breaking changes, etc. <br>
**	|-->:

### Additional context

Add any other context about the problem here. <br>
**	|-->:

### System under test

Please complete the following information.

- OS: [e.g. Windows 10]
- OS Arch.: [e.g. X64]
- LibreOffice Component: [e.g. Main, Writer, Calc]
- LibreOffice version: [e.g. 7.3.4.2]

